### PR TITLE
fix: class selector in students filters

### DIFF
--- a/src/features/Students/StudentsFilters/index.jsx
+++ b/src/features/Students/StudentsFilters/index.jsx
@@ -38,7 +38,7 @@ const StudentsFilters = () => {
   const courses = useSelector((state) => state.common.allCourses.data)
     .map((course) => ({ label: course.masterCourseName, value: course.masterCourseName }));
   const classes = useSelector((state) => state.common.allClasses.data)
-    .map((course) => ({ label: course.masterCourseName, value: course.masterCourseName }));
+    .map((classElement) => ({ label: classElement.className, value: classElement.className }));
 
   const [studentsData, setStudentsData] = useState({
     ...initialStudentState,


### PR DESCRIPTION
# Description

In this PR is fixed the selector for classes in `StudentsFilters` the selector wasn't showing the correct labels for classes.

### How to test

Clone the instructors Portal MFE
```Bash
     git clone https://github.com/Pearson-Advance/frontend-app-instructors-portal
```
Install the packages 📦.
```Bash
     npm i
```
Start project.
```Bash
     npm start
```

Finally, go to http://localhost:1990/students and filter by class.