### PR TITLE
refactor: sort institution select alphabetically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-intl": "^5.25.1",
-        "react-paragon-topaz": "1.18.5",
+        "react-paragon-topaz": "1.20.0",
         "react-redux": "7.2.9",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
@@ -15193,9 +15193,10 @@
       }
     },
     "node_modules/react-paragon-topaz": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.18.5.tgz",
-      "integrity": "sha512-2roPAL8WI3uByElMmLQDiDBwFGOIF1ub5BXuwq1XHQPJBJaKncBVFqrRO9KPH8YMgp2R0Mlv8ivx4y4HzWTpSw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.20.0.tgz",
+      "integrity": "sha512-LxdkTWzgWe4FJ/wYXvaEE6lbFOZYjDPQ6KVzkgTYZ9BGi6W4iWL8gt6p90L8gYWdoPvRn3ypMasYbPn3o9CFrg==",
+      "license": "ISC",
       "dependencies": {
         "@babel/runtime": "7.25.6",
         "@edx/frontend-platform": "4.5.1",
@@ -30231,9 +30232,9 @@
       }
     },
     "react-paragon-topaz": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.18.5.tgz",
-      "integrity": "sha512-2roPAL8WI3uByElMmLQDiDBwFGOIF1ub5BXuwq1XHQPJBJaKncBVFqrRO9KPH8YMgp2R0Mlv8ivx4y4HzWTpSw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.20.0.tgz",
+      "integrity": "sha512-LxdkTWzgWe4FJ/wYXvaEE6lbFOZYjDPQ6KVzkgTYZ9BGi6W4iWL8gt6p90L8gYWdoPvRn3ypMasYbPn3o9CFrg==",
       "requires": {
         "@babel/runtime": "7.25.6",
         "@edx/frontend-platform": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-intl": "^5.25.1",
-    "react-paragon-topaz": "1.18.5",
+    "react-paragon-topaz": "1.20.0",
     "react-redux": "7.2.9",
     "react-router": "5.2.1",
     "react-router-dom": "5.3.0",

--- a/src/features/Main/data/thunks.js
+++ b/src/features/Main/data/thunks.js
@@ -1,5 +1,6 @@
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform';
+import { sortAlphabetically } from 'react-paragon-topaz';
 import { getInstitutionName } from 'features/Main/data/api';
 import {
   updateSelectedInstitutions,
@@ -15,7 +16,8 @@ function fetchInstitutionData() {
     dispatch(updateSelectedInstitutions({ status: RequestStatus.LOADING }));
     try {
       const { data } = camelCaseObject(await getInstitutionName());
-      dispatch(updateSelectedInstitutions({ status: RequestStatus.SUCCESS, data }));
+      const sortedData = sortAlphabetically(data, 'name');
+      dispatch(updateSelectedInstitutions({ status: RequestStatus.SUCCESS, data: sortedData }));
     } catch (error) {
       dispatch(updateSelectedInstitutions({ status: RequestStatus.ERROR, error }));
       logError(error);


### PR DESCRIPTION
### Ticket
PADV-1159

### Description

This PR modifies the institution selector so this is sorted alphabetically. To be able to use the `sortAlphabetically` method, it was necessary to upgrade the library `react-paragon-topaz`

### Screenshots
![image](https://github.com/user-attachments/assets/e2d1df67-799f-42aa-816d-dd3498d8c93b)
