### PR TITLE
PADV-1876 feat: add button to launch lab summary

### DIFF
--- a/src/features/Classes/ClassDetailPage/__test__/index.test.jsx
+++ b/src/features/Classes/ClassDetailPage/__test__/index.test.jsx
@@ -64,6 +64,7 @@ const mockStore = {
           maxStudents: 200,
           startDate: '2024-04-03T00:00:00Z',
           endDate: null,
+          labSummaryUrl: 'https: //',
         },
       ],
     },
@@ -110,13 +111,14 @@ describe('ClassDetailPage', () => {
     });
   });
 
-  test('renders the Gradebook option in the dropdown', () => {
+  test('renders extra options in the dropdown', () => {
     const component = renderClassDetailPage();
 
     const dropdownToggle = component.getByLabelText('menu for actions');
     fireEvent.click(dropdownToggle);
 
     expect(component.getByText('Gradebook')).toBeInTheDocument();
+    expect(component.getByText('Lab summary')).toBeInTheDocument();
   });
 
   test('opens Gradebook in a new tab', async () => {

--- a/src/features/Classes/ClassDetailPage/index.jsx
+++ b/src/features/Classes/ClassDetailPage/index.jsx
@@ -89,11 +89,22 @@ const ClassDetailPage = () => {
     window.open(`${gradebookUrl}/gradebook/${classId}`, '_blank', 'noopener,noreferrer');
   };
 
+  const handleLabButton = () => {
+    window.open(classInfo?.labSummaryUrl, '_blank', 'noopener,noreferrer');
+  };
+
   const extraOptions = [
     {
       handleClick: handleGradebookButton,
       iconSrc: <i className="fa-regular fa-book mr-3" />,
       label: 'Gradebook',
+      visible: true,
+    },
+    {
+      handleClick: handleLabButton,
+      iconSrc: <i className="fa-regular fa-rectangle-list mr-3" />,
+      label: 'Lab summary',
+      visible: !!classInfo?.labSummaryUrl,
     },
   ];
 

--- a/src/features/Classes/ClassesPage/columns.jsx
+++ b/src/features/Classes/ClassesPage/columns.jsx
@@ -65,6 +65,7 @@ const columns = [
     Cell: ({ row }) => {
       const {
         classId,
+        labSummaryUrl,
       } = row.original;
 
       const gradebookUrl = getConfig().GRADEBOOK_MICROFRONTEND_URL || getConfig().LMS_BASE_URL;
@@ -73,11 +74,23 @@ const columns = [
         const decodedClassId = decodeURIComponent(classId);
         window.open(`${gradebookUrl}/gradebook/${decodedClassId}`, '_blank', 'noopener,noreferrer');
       };
+
+      const handleLabButton = () => {
+        window.open(labSummaryUrl, '_blank', 'noopener,noreferrer');
+      };
+
       const extraOptions = [
         {
           handleClick: handleGradebookButton,
           iconSrc: <i className="fa-regular fa-book mr-3" />,
           label: 'Gradebook',
+          visible: true,
+        },
+        {
+          handleClick: handleLabButton,
+          iconSrc: <i className="fa-regular fa-rectangle-list mr-3" />,
+          label: 'Lab summary',
+          visible: !!labSummaryUrl,
         },
       ];
 

--- a/src/features/Main/ActionsDropdown/__test__/index.test.jsx
+++ b/src/features/Main/ActionsDropdown/__test__/index.test.jsx
@@ -5,8 +5,8 @@ import ActionsDropdown from '..';
 
 describe('ActionsDropdown', () => {
   const optionsMock = [
-    { handleClick: jest.fn(), label: 'Option 1' },
-    { handleClick: jest.fn(), label: 'Option 2' },
+    { handleClick: jest.fn(), label: 'Option 1', visible: true },
+    { handleClick: jest.fn(), label: 'Option 2', visible: true },
   ];
 
   test('Should render the dropdown toggle button', () => {

--- a/src/features/Main/ActionsDropdown/index.jsx
+++ b/src/features/Main/ActionsDropdown/index.jsx
@@ -12,6 +12,7 @@ import Option from './Option';
  *   - `iconSrc`: The URL of the icon to show for the option.
  *   - `handleClick`: The function to call when the option is clicked.
  *   - `label`: The text to display for the option.
+ *   - `visible`: Whether the option is visible
  * @param {boolean} props.vertIcon Whether to use the vertical "more" icon.
  *
  * @returns {ReactElement} The rendered dropdown menu.
@@ -29,9 +30,12 @@ const ActionsDropdown = ({ options, vertIcon }) => (
       alt="menu for actions"
     />
     <Dropdown.Menu>
-      {options.map((option) => (
-        <Option key={option.label} {...option} />
-      ))}
+      {options.map((option) => {
+        if (option.visible) {
+          return <Option key={option.label} {...option} />;
+        }
+        return null;
+      })}
     </Dropdown.Menu>
   </Dropdown>
 );
@@ -41,6 +45,7 @@ ActionsDropdown.propTypes = {
     iconSrc: PropTypes.string,
     handleClick: PropTypes.func.isRequired,
     label: PropTypes.string.isRequired,
+    visible: PropTypes.bool,
   })).isRequired,
   vertIcon: PropTypes.bool,
 };

--- a/src/features/Main/index.jsx
+++ b/src/features/Main/index.jsx
@@ -77,7 +77,7 @@ const Main = () => {
   return (
     <BrowserRouter basename={getConfig().INSTRUCTOR_PORTAL_PATH}>
       <Header />
-      <main className="d-flex page-wrapper">
+      <main className="d-flex pageWrapper">
         {isLoadingClasses && (
           <div className="w-100 h-100 d-flex justify-content-center align-items-center mt-4">
             <Spinner

--- a/src/features/Main/index.scss
+++ b/src/features/Main/index.scss
@@ -1,6 +1,6 @@
 @import 'assets/colors.scss';
 
-.page-wrapper {
+.pageWrapper {
   min-height: calc(100vh - 222px);
   background-color: $bg-main-color;
   background-image: url('https://pearson-production-media.s3.amazonaws.com/Geo+Shape+instructor.svg');
@@ -10,7 +10,7 @@
 }
 
 @media (max-width: 700px) {
-  .page-wrapper {
+  .pageWrapper {
     background-size: 90%;
   }
 }


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-1876

### Description
Add button to launch lab summary

### Changes made
Add button if the course has XL or skillable labs
Change page wrapper class to match with styles in paragon library
Update test

### Screenshoots
![Screenshot from 2025-01-10 13-05-10](https://github.com/user-attachments/assets/b6bca723-2486-4a7c-9f8e-11f11bb1d21a)
![Screenshot from 2025-01-10 13-05-26](https://github.com/user-attachments/assets/3b3008e4-c8db-4790-ba8e-fe33ab6e9485)

### How to test
Have skillable installed
In course operations change to branch vue/PADV-1880

Clone the Instructor Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1990 -> classes -> select a class