### PR TITLE
feat: update react-paragon-topaz-version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-intl": "^5.25.1",
-        "react-paragon-topaz": "^1.26.0",
+        "react-paragon-topaz": "1.27.0",
         "react-redux": "7.2.9",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
@@ -15193,9 +15193,9 @@
       }
     },
     "node_modules/react-paragon-topaz": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.26.0.tgz",
-      "integrity": "sha512-uoaIICh79aM5OvpdKiED7+Ys6EGjR7mtmrOPrgk3TfjH2oABUD+kXFeDN4xraTQ73txZbqQ6RW/esyhMzWgm6g==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.27.0.tgz",
+      "integrity": "sha512-DEj5+dLOPb8/lpQsi10TyuuoN43XiLXct/a4Kc6bpg7I2xlJOXmZkg5F0OfODJvwlphiUcAd1U6FB9Z4l1e4fQ==",
       "dependencies": {
         "@babel/runtime": "7.25.6",
         "@edx/frontend-platform": "4.5.1",
@@ -30231,9 +30231,9 @@
       }
     },
     "react-paragon-topaz": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.26.0.tgz",
-      "integrity": "sha512-uoaIICh79aM5OvpdKiED7+Ys6EGjR7mtmrOPrgk3TfjH2oABUD+kXFeDN4xraTQ73txZbqQ6RW/esyhMzWgm6g==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.27.0.tgz",
+      "integrity": "sha512-DEj5+dLOPb8/lpQsi10TyuuoN43XiLXct/a4Kc6bpg7I2xlJOXmZkg5F0OfODJvwlphiUcAd1U6FB9Z4l1e4fQ==",
       "requires": {
         "@babel/runtime": "7.25.6",
         "@edx/frontend-platform": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-intl": "^5.25.1",
-    "react-paragon-topaz": "1.26.0",
+    "react-paragon-topaz": "1.27.0",
     "react-redux": "7.2.9",
     "react-router": "5.2.1",
     "react-router-dom": "5.3.0",


### PR DESCRIPTION
# Description


This PR updates the version of the lib `react-paragon-topaz` this change is part of issue [PADV-1862](https://agile-jira.pearson.com/browse/PADV-1862)

## Change log
- Updated npm version


### How to test
- Install the updated version
```bash
 npm install
```

- In [site configurations](http://localhost:18000/admin/site_configuration) `localhost:1990` add the setting `MAINTENANCE_BANNER_TEXT` inside of `MFE_CONFIG`

```bash

 "MFE_CONFIG": {
     "MAINTENANCE_BANNER_TEXT": "Your custom text here" 
}
```

Wait one moment, then you should be able to see the dismissible banner in the entire site.

