### PR TITLE
fix: set input type to text for student name/email field

### DIFF
--- a/src/features/Students/StudentsFilters/index.jsx
+++ b/src/features/Students/StudentsFilters/index.jsx
@@ -121,7 +121,7 @@ const StudentsFilters = () => {
         <Form.Row className="col-12">
           <Form.Group as={Col}>
             <Form.Control
-              type={`${studentsData.checkboxSelection === 'name' ? 'text' : 'email'}`}
+              type="text"
               floatingLabel={`Student ${studentsData.checkboxSelection === 'name' ? 'name' : 'email'}`}
               name="instructor_name"
               placeholder={`Student ${studentsData.checkboxSelection === 'name' ? 'name' : 'email'}`}


### PR DESCRIPTION
# Descriptio
> [!WARNING]  
> This PR is reopen, the previous one was pointing to the wrong branch https://github.com/Pearson-Advance/frontend-app-instructors-portal/pull/51

_Visual explanation ( srry guys ):_
![image](https://github.com/user-attachments/assets/ed42db6b-7a6f-4482-808f-5e92e3ccff39)



This PR updates the input type in **StudentsFilter**, changing it from `email` to `text` to enable **partial email searches**. Previously, searches required a full email match, but with this change, users can find students by entering only a part of their email.  

This improves usability when filtering students based on incomplete email information.  

This PR resolves [PADV-1907](https://agile-jira.pearson.com/browse/PADV-1907)  

## Change log  
- Changed input type from `email` to `text` in **StudentsFilter**  
- Enabled partial email searches  

### Visual results  
_No visual changes_

### How to test  
1. Go to the **StudentsFilter** form.  
2. Enter a partial email in the search field.  
3. The table should display students matching the partial email input.  
4. You should be able to find a student without entering their full email address.  
