### PR TITLE
feat: full username instead of username

### DIFF
--- a/src/features/Main/Header/index.jsx
+++ b/src/features/Main/Header/index.jsx
@@ -11,7 +11,7 @@ import { updateUsername } from 'features/Main/data/slice';
 export const Header = () => {
   const dispatch = useDispatch();
   const { authenticatedUser } = useContext(AppContext);
-  const userName = authenticatedUser.username;
+  const userName = authenticatedUser.name || authenticatedUser.username;
   const questionsLink = () => `${getConfig().HEADER_QUESTIONS_LINK}`;
   const platformName = getConfig().PLATFORM_NAME ? getConfig().PLATFORM_NAME : 'Pearson Skilling Instructor';
   dispatch(updateUsername(userName));


### PR DESCRIPTION
# Description  

> [!WARNING]  
> This PR was close by accident, the original was https://github.com/Pearson-Advance/frontend-app-instructors-portal/pull/50 sorry for the inconvenience.

This PR updates the **header** to display the user's **full name** instead of their username. If the user **does not have a full name configured**, the username will still be displayed as the default value.  

This PR resolves [PADV-2063](https://agile-jira.pearson.com/browse/PADV-2063)  

## Change log  
- Updated the header to display the **full name** instead of the username.  
- If the full name is not available, the username remains as the fallback.  

### Visual results  
_No visual changes._  

### How to test  
1. Start the application.  
2. Check the **header** to confirm that the **user's full name** is displayed.  
3. If the user does not have a full name set, the username should still be displayed.  
