### PR TITLE
fix: username when value is 'nofullname'

### DIFF
--- a/src/features/Main/Header/index.jsx
+++ b/src/features/Main/Header/index.jsx
@@ -11,10 +11,12 @@ import { updateUsername } from 'features/Main/data/slice';
 export const Header = () => {
   const dispatch = useDispatch();
   const { authenticatedUser } = useContext(AppContext);
-  const userName = authenticatedUser.name || authenticatedUser.username;
+  const userName = !authenticatedUser.name || authenticatedUser.name === 'nofullname'
+    ? authenticatedUser.username
+    : authenticatedUser.name;
   const questionsLink = () => `${getConfig().HEADER_QUESTIONS_LINK}`;
   const platformName = getConfig().PLATFORM_NAME ? getConfig().PLATFORM_NAME : 'Pearson Skilling Instructor';
-  dispatch(updateUsername(userName));
+  dispatch(updateUsername(authenticatedUser.username));
 
   return (
     <HeaderBase


### PR DESCRIPTION
# Description  

This PR resolves [PADV-2063](https://agile-jira.pearson.com/browse/PADV-2063)  

## Change log  
- Fixed an issue where the header displayed `nofullname` when the authenticated user's `name` existed but contained that value.  


### Visual results  

#### Before  
- The header displayed `"nofullname"` when the `user.profile.name` field existed but was unset by the user.  
![image](https://github.com/user-attachments/assets/dba76c96-2b85-4d0b-92a0-7ac1ea77b376)


#### After  
- The header now correctly displays the `username` when `user.profile.name` is unset or has `nofullname`.  
![image](https://github.com/user-attachments/assets/ea7a3efe-9bae-4486-b02b-5e01a046ae2c)


### How to test  
1. Use a test user whose `user.profile.name` field is set. The header should display that name.  
2. Use another test user with no value set for `user.profile.name` or with `"nofullname"`. The header should now display the `username` instead.  
3. Verify that removing the `user.profile.name` value also results in the `username` being displayed.  
