### PR TITLE
refactor: hardcoded fullname conditional in header

### DIFF
--- a/src/features/Main/Header/index.jsx
+++ b/src/features/Main/Header/index.jsx
@@ -11,9 +11,7 @@ import { updateUsername } from 'features/Main/data/slice';
 export const Header = () => {
   const dispatch = useDispatch();
   const { authenticatedUser } = useContext(AppContext);
-  const userName = !authenticatedUser.name || authenticatedUser.name === 'nofullname'
-    ? authenticatedUser.username
-    : authenticatedUser.name;
+  const displayName = authenticatedUser?.name || authenticatedUser.username;
   const questionsLink = () => `${getConfig().HEADER_QUESTIONS_LINK}`;
   const platformName = getConfig().PLATFORM_NAME ? getConfig().PLATFORM_NAME : 'Pearson Skilling Instructor';
   dispatch(updateUsername(authenticatedUser.username));
@@ -31,7 +29,7 @@ export const Header = () => {
         <Dropdown className="dropdown-user">
           <Dropdown.Toggle variant="success" id="dropdown-basic-1">
             <i className="fa-regular fa-user icon" />
-            {userName}
+            {displayName}
           </Dropdown.Toggle>
           <Dropdown.Menu>
             <Dropdown.Item


### PR DESCRIPTION
# Description

This PR is part of [PADV-2063](https://agile-jira.pearson.com/browse/PADV-2063) removes the hardcoded logic used to handle users without a full name, as it was fragile and subject to potential changes. Instead, it defaults to showing "nofullname" when no full name is available, relying on the backend to eventually update this behavior. If the user has a valid value, it displays the full name or "nofullname"; otherwise, it shows the username. Additionally, the variable responsible for displaying the name was refactored for better clarity.

## Change log
- Removed hardcoded logic for handling users without a full name.
- Now defaults to showing `nofullname` if no full name is provided, relying on backend to handle this.
- Small refactor to the variable responsible for displaying the name for improved clarity.

### How to test
- Launch the platform and log in with different users:
  - A user with a full name.
  - A user without a full name.
  - A user with the `name` field set to `nofullname`.