### PR TITLE
PADV-2290 feat: add query param to identify instructor portal

### DIFF
--- a/src/features/Classes/ClassDetailPage/index.jsx
+++ b/src/features/Classes/ClassDetailPage/index.jsx
@@ -54,6 +54,7 @@ const ClassDetailPage = () => {
         page: currentPage,
         class_name: className,
         institution_id: institution?.id,
+        limit: true,
       };
       // Leaves a gap time space to prevent being override by ActiveTabUpdater component
       setTimeout(() => dispatch(updateActiveTab(previousPage)), 100);

--- a/src/features/Common/data/__test__/api.test.js
+++ b/src/features/Common/data/__test__/api.test.js
@@ -43,6 +43,7 @@ describe('Common api services', () => {
           limit: false,
           page: '',
           page_size: MAX_TABLE_RECORDS,
+          instructor_portal: true,
         },
       },
     );

--- a/src/features/Common/data/__test__/api.test.js
+++ b/src/features/Common/data/__test__/api.test.js
@@ -1,6 +1,6 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getClassesByInstructor } from 'features/Common/data/api';
-import { MAX_TABLE_RECORDS } from 'features/constants';
+import { defaultParamsService } from 'features/constants';
 
 jest.mock('@edx/frontend-platform/auth', () => ({
   getAuthenticatedHttpClient: jest.fn(),
@@ -40,10 +40,7 @@ describe('Common api services', () => {
       {
         params: {
           instructor,
-          limit: false,
-          page: '',
-          page_size: MAX_TABLE_RECORDS,
-          instructor_portal: true,
+          ...defaultParamsService,
         },
       },
     );

--- a/src/features/Common/data/api.js
+++ b/src/features/Common/data/api.js
@@ -1,7 +1,7 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform';
 
-import { MAX_TABLE_RECORDS } from 'features/constants';
+import { defaultParamsService } from 'features/constants';
 
 /* Fetch classes by instructor username with optional filters and pagination.
  *
@@ -14,16 +14,9 @@ import { MAX_TABLE_RECORDS } from 'features/constants';
  */
 
 function getClassesByInstructor(userName, options = {}) {
-  const defaultParams = {
-    limit: false,
-    page: '',
-    page_size: MAX_TABLE_RECORDS,
-    instructor_portal: true,
-  };
-
   const params = {
     instructor: userName,
-    ...defaultParams,
+    ...defaultParamsService,
     ...options,
   };
 
@@ -44,16 +37,9 @@ function getClassesByInstructor(userName, options = {}) {
  * @returns {Promise} - A promise that resolves to the response from the API.
  */
 function getCoursesByInstructor(userName, options = {}) {
-  const defaultParams = {
-    limit: false,
-    page: '',
-    page_size: MAX_TABLE_RECORDS,
-    instructor_portal: true,
-  };
-
   const params = {
     instructor: userName,
-    ...defaultParams,
+    ...defaultParamsService,
     ...options,
   };
 

--- a/src/features/Common/data/api.js
+++ b/src/features/Common/data/api.js
@@ -18,6 +18,7 @@ function getClassesByInstructor(userName, options = {}) {
     limit: false,
     page: '',
     page_size: MAX_TABLE_RECORDS,
+    instructor_portal: true,
   };
 
   const params = {
@@ -47,6 +48,7 @@ function getCoursesByInstructor(userName, options = {}) {
     limit: false,
     page: '',
     page_size: MAX_TABLE_RECORDS,
+    instructor_portal: true,
   };
 
   const params = {

--- a/src/features/Instructor/data/__test__/api.test.js
+++ b/src/features/Instructor/data/__test__/api.test.js
@@ -36,7 +36,13 @@ describe('Instructor services', () => {
     expect(httpClientMock.get).toHaveBeenCalledTimes(1);
     expect(httpClientMock.get).toHaveBeenCalledWith(
       'http://localhost:18000/pearson_course_operation/api/v2/instructors/',
-      { params: { instructor_email: email, limit: false } },
+      {
+        params: {
+          instructor_email: email,
+          limit: false,
+          instructor_portal: true,
+        },
+      },
     );
   });
 

--- a/src/features/Instructor/data/api.js
+++ b/src/features/Instructor/data/api.js
@@ -4,6 +4,7 @@ import { getConfig } from '@edx/frontend-platform';
 function getInstructorByEmail(email, options = {}) {
   const defaultParams = {
     limit: false,
+    instructor_portal: true,
   };
 
   const params = {

--- a/src/features/Main/data/api.js
+++ b/src/features/Main/data/api.js
@@ -2,8 +2,12 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform';
 
 function getInstitutionName() {
+  const params = {
+    instructor_portal: true,
+  };
   return getAuthenticatedHttpClient().get(
     `${getConfig().COURSE_OPERATIONS_API_V2_BASE_URL}/institutions/?limit=false`,
+    { params },
   );
 }
 

--- a/src/features/Students/StudentsPage/index.jsx
+++ b/src/features/Students/StudentsPage/index.jsx
@@ -23,7 +23,12 @@ const StudentsPage = () => {
 
   useEffect(() => {
     if (username) {
-      dispatch(fetchStudentsData(username, { page: currentPage, institution_id: institution?.id, ...filters }));
+      dispatch(fetchStudentsData(username, {
+        page: currentPage,
+        institution_id: institution?.id,
+        limit: true,
+        ...filters,
+      }));
     }
 
     return () => {

--- a/src/features/Students/data/__test__/api.test.js
+++ b/src/features/Students/data/__test__/api.test.js
@@ -1,7 +1,7 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 import { getStudentsbyInstructor } from 'features/Students/data/api';
-import { MAX_TABLE_RECORDS } from 'features/constants';
+import { defaultParamsService } from 'features/constants';
 
 jest.mock('@edx/frontend-platform/auth', () => ({
   getAuthenticatedHttpClient: jest.fn(),
@@ -37,7 +37,8 @@ describe('getStudentsbyInstructor', () => {
       'http://localhost:18000/pearson_course_operation/api/v2/students/',
       {
         params: {
-          instructor, page: 1, page_size: MAX_TABLE_RECORDS, instructor_portal: true,
+          instructor,
+          ...defaultParamsService,
         },
       },
     );

--- a/src/features/Students/data/__test__/api.test.js
+++ b/src/features/Students/data/__test__/api.test.js
@@ -35,7 +35,11 @@ describe('getStudentsbyInstructor', () => {
     expect(httpClientMock.get).toHaveBeenCalledTimes(1);
     expect(httpClientMock.get).toHaveBeenCalledWith(
       'http://localhost:18000/pearson_course_operation/api/v2/students/',
-      { params: { instructor, page: 1, page_size: MAX_TABLE_RECORDS } },
+      {
+        params: {
+          instructor, page: 1, page_size: MAX_TABLE_RECORDS, instructor_portal: true,
+        },
+      },
     );
   });
 });

--- a/src/features/Students/data/api.js
+++ b/src/features/Students/data/api.js
@@ -16,6 +16,7 @@ function getStudentsbyInstructor(userName, options = {}) {
   const defaultParams = {
     page: initialPage,
     page_size: MAX_TABLE_RECORDS,
+    instructor_portal: true,
   };
 
   const params = {

--- a/src/features/Students/data/api.js
+++ b/src/features/Students/data/api.js
@@ -1,7 +1,7 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform';
 
-import { initialPage, MAX_TABLE_RECORDS } from 'features/constants';
+import { defaultParamsService } from 'features/constants';
 
 /* Fetch students by instructor username with optional filters
  *
@@ -13,15 +13,9 @@ import { initialPage, MAX_TABLE_RECORDS } from 'features/constants';
  */
 
 function getStudentsbyInstructor(userName, options = {}) {
-  const defaultParams = {
-    page: initialPage,
-    page_size: MAX_TABLE_RECORDS,
-    instructor_portal: true,
-  };
-
   const params = {
     instructor: userName,
-    ...defaultParams,
+    ...defaultParamsService,
     ...options,
   };
 

--- a/src/features/constants.js
+++ b/src/features/constants.js
@@ -90,3 +90,17 @@ export const allInstitutionsOption = {
   label: 'All my institutions',
   value: 'all_institutions',
 };
+
+/**
+ * Default query parameters for service requests.
+ * @property {boolean} limit - Indicates if pagination is applied.
+ * @property {string|number} page - Current page number for pagination.
+ * @property {number} page_size - Number of records per page.
+ * @property {boolean} instructor_portal - Flag to indicate if the request is from the Instructor Portal.
+ */
+export const defaultParamsService = {
+  limit: false,
+  page: initialPage,
+  page_size: MAX_TABLE_RECORDS,
+  instructor_portal: true,
+};


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2290

### Description
Add query param to services to identify instructor portal

### Changes made
Include query param _instructor_portal: true_ to identify IP
Update test

### How to test
Clone the Institution Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1990/

Access to instructor portal with a user with 'INSTRUCTOR' role 
Only should see the institutions which the instructor is part even without classes assigned