### PR TITLE
PADV-2223 fix: add institution portal path to url

### DIFF
--- a/src/features/Main/UnauthorizedPage/__test__/index.test.jsx
+++ b/src/features/Main/UnauthorizedPage/__test__/index.test.jsx
@@ -6,6 +6,7 @@ import UnauthorizedPage from 'features/Main/UnauthorizedPage';
 jest.mock('@edx/frontend-platform', () => ({
   getConfig: jest.fn(() => ({
     LMS_BASE_URL: 'http://localhost:18000',
+    INSTITUTION_PORTAL_PATH: '/certprep',
   })),
 }));
 
@@ -16,7 +17,7 @@ describe('Unauthorized Component', () => {
     expect(getByText(/Pearson Skilling Suite Admin Portal/i)).toBeInTheDocument();
 
     // Check the link is rendered correctly
-    const link = getByRole('link', { name: 'http://localhost:18000' });
-    expect(link).toHaveAttribute('href', 'http://localhost:18000');
+    const link = getByRole('link', { name: 'http://localhost:18000/certprep' });
+    expect(link).toHaveAttribute('href', 'http://localhost:18000/certprep');
   });
 });

--- a/src/helpers/index.jsx
+++ b/src/helpers/index.jsx
@@ -85,11 +85,14 @@ export const stringToDateType = (date) => new Date(date.replace(/-/g, '\/'));
  */
 export const getMessageUnauthorized = () => {
   const LMS_URL = getConfig().LMS_BASE_URL;
+  const { INSTITUTION_PORTAL_PATH } = getConfig();
+  const skillingURL = INSTITUTION_PORTAL_PATH ? LMS_URL + INSTITUTION_PORTAL_PATH : LMS_URL;
+
   return (
     <p>
       Oops! You&apos;ve landed on the Instructor Portal but have no Instructor role.
       If you are an admin, you may administer students, instructors, and classes in the Pearson Skilling Suite Admin Portal at{' '}
-      <a href={LMS_URL} target="_blank" rel="noopener noreferrer">{LMS_URL}</a>.{' '}
+      <a href={skillingURL} target="_blank" rel="noopener noreferrer">{skillingURL}</a>.{' '}
       If you are an instructor, please contact your administrator for access to the Instructor Portal.
     </p>
   );


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2223

### Description
Add institution portal path to url in unauthorized message

### How to test
Clone the Institution Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1990/

Access to instructor portal with a user without 'INSTRUCTOR' role

