### PR TITLE
feat: add enrollment button visibility based on instructor privileges

### DIFF
--- a/src/features/Classes/ClassDetailPage/__test__/index.test.jsx
+++ b/src/features/Classes/ClassDetailPage/__test__/index.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route } from 'react-router-dom';
 import '@testing-library/jest-dom/extend-expect';
 
@@ -137,5 +137,51 @@ describe('ClassDetailPage', () => {
         'noopener,noreferrer',
       );
     });
+  });
+});
+
+describe('Enrollment access', () => {
+  test('Should hide enroll student button if the instructor does not have the privilege', () => {
+    const state = {
+      ...mockStore,
+      instructor: {
+        info: {
+          hasEnrollmentPrivilege: false,
+        },
+      },
+    };
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={[`/classes/${classId}`]}>
+        <Route path="/classes/:classId">
+          <ClassDetailPage />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: state },
+    );
+
+    expect(screen.queryByText('Invite student to enroll')).not.toBeInTheDocument();
+  });
+
+  test('Should display enroll student button if the instructor has the privilege', () => {
+    const state = {
+      ...mockStore,
+      instructor: {
+        info: {
+          hasEnrollmentPrivilege: true,
+        },
+      },
+    };
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={[`/classes/${classId}`]}>
+        <Route path="/classes/:classId">
+          <ClassDetailPage />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: state },
+    );
+
+    expect(screen.getByText('Invite student to enroll')).toBeInTheDocument();
   });
 });

--- a/src/features/Classes/ClassDetailPage/index.jsx
+++ b/src/features/Classes/ClassDetailPage/index.jsx
@@ -36,6 +36,10 @@ const ClassDetailPage = () => {
   const username = useSelector((state) => state.main.username);
   const institution = useSelector((state) => state.main.institution);
   const [classInfo] = useSelector((state) => state.common.allClasses?.data);
+
+  // Set to 'true' by default to maintain normal behavior.
+  const enableEnrollmentPrivilege = getConfig()?.SHOW_INSTRUCTOR_FEATURES || true;
+  const { hasEnrollmentPrivilege = enableEnrollmentPrivilege } = useSelector((state) => state.instructor.info);
   const COLUMNS = useMemo(() => columns, []);
 
   const [currentPage, setCurrentPage] = useState(initialPage);
@@ -136,12 +140,16 @@ const ClassDetailPage = () => {
           </div>
           <InstructorCard />
           <div className="d-flex justify-content-end my-3 align-items-center ">
-            <Button
-              onClick={handleEnrollStudentModal}
-              className="text-decoration-none text-primary bg-white"
-            >
-              Invite student to enroll
-            </Button>
+            {
+              hasEnrollmentPrivilege && (
+                <Button
+                  onClick={handleEnrollStudentModal}
+                  className="text-decoration-none text-primary bg-white"
+                >
+                  Invite student to enroll
+                </Button>
+              )
+            }
             <ActionsDropdown options={extraOptions} />
           </div>
           <Table

--- a/src/features/Instructor/Profile/index.jsx
+++ b/src/features/Instructor/Profile/index.jsx
@@ -16,7 +16,6 @@ import Availability from 'features/Instructor/Availability';
 
 import Table from 'features/Main/Table';
 import { getClasses } from 'features/Classes/data';
-import { fetchInstructorProfile } from 'features/Instructor/data';
 import { resetClassesTable, updateCurrentPage } from 'features/Classes/data/slice';
 
 import { columns } from 'features/Instructor/Profile/columns';
@@ -50,12 +49,6 @@ const Profile = () => {
     setCurrentPage(targetPage);
     dispatch(updateCurrentPage(targetPage));
   };
-
-  useEffect(() => {
-    if (instructorEmail) {
-      dispatch(fetchInstructorProfile(instructorEmail, { institution_id: institution?.id }));
-    }
-  }, [instructorEmail, dispatch, instructorUserName, institution]);
 
   useEffect(() => {
     if (instructorEmail) {

--- a/src/features/Main/index.jsx
+++ b/src/features/Main/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   BrowserRouter,
@@ -11,6 +11,7 @@ import {
 
 import { Container, Spinner } from '@edx/paragon';
 import { getConfig } from '@edx/frontend-platform';
+import { AppContext } from '@edx/frontend-platform/react';
 
 import { Banner, getUserRoles, USER_ROLES } from 'react-paragon-topaz';
 
@@ -27,6 +28,7 @@ import InstitutionSelector from 'features/Main/InstitutionSelector';
 import Profile from 'features/Instructor/Profile';
 import UnauthorizedPage from 'features/Main/UnauthorizedPage';
 
+import { fetchInstructorProfile } from 'features/Instructor/data';
 import { fetchInstitutionData, fetchClassAuthorization } from 'features/Main/data/thunks';
 import { updateSelectedInstitution } from 'features/Main/data/slice';
 
@@ -39,8 +41,10 @@ const Main = () => {
   const location = useLocation();
   const dispatch = useDispatch();
   const roles = getUserRoles();
+  const { authenticatedUser } = useContext(AppContext);
 
   const institutions = useSelector((state) => state.main.institutions.data);
+  const institution = useSelector((state) => state.main.institution);
   const username = useSelector((state) => state.main.username);
   const classes = useSelector((state) => state.main.classes);
 
@@ -50,6 +54,7 @@ const Main = () => {
   const isAuthorizedUser = roles.includes(USER_ROLES.INSTRUCTOR);
 
   const searchParams = new URLSearchParams(location.search);
+  const instructorEmail = authenticatedUser.email;
 
   useEffect(() => {
     dispatch(fetchInstitutionData());
@@ -60,6 +65,12 @@ const Main = () => {
       dispatch(fetchClassAuthorization(username));
     }
   }, [dispatch, username]);
+
+  useEffect(() => {
+    if (instructorEmail) {
+      dispatch(fetchInstructorProfile(instructorEmail, { institution_id: institution?.id }));
+    }
+  }, [instructorEmail, dispatch, institution]);
 
   useEffect(() => {
     if (institutions?.length === 1) {


### PR DESCRIPTION
# Description

In this PR is implemented the privilege of instructor, if the instructor has the permission, the enroll button will be displayed. 

This PR resolves [PADV-2136](https://agile-jira.pearson.com/browse/PADV-2136)

## Change log
- Added privilege validation.

### How to test
- Set in the site configurations the flag `SHOW_INSTRUCTOR_FEATURES` in `true`.
> [!IMPORTANT]  
> Make sure to have the backend updated, other wise override the request
`/instructors/?instructor_email={{email}}&limit=false.`

Respose content:
```javascript
[{
    "instructor_id": 7,
    "instructor_image": "",
    "instructor_username": "instructor5",
    "instructor_name": "Instructor 5",
    "instructor_email": "instructor5@example.com",
    "last_access": "2025-04-23T16:23:00.957384Z",
    "created": "2025-03-12T17:54:07Z",
    "classes": 1,
    "active": true,
    "has_enrollment_privilege": true
}]
``` 
- Go to CPM in `/institution-portal/instructors` then add a new instructor, make sure to toggle the input in true.
- Open IP then go to `/classes/:class_id` if `has_enrollment_privilege` is `true` you should be able to see the button.
> [!NOTE]  
> Currently, the button appears as it normally would. However, once the backend integration is complete, its visibility will be dynamically controlled based on the user's enrollment privileges.

