### PR TITLE
fix: institution param in services

### DIFF
--- a/src/features/Classes/ClassDetailPage/index.jsx
+++ b/src/features/Classes/ClassDetailPage/index.jsx
@@ -53,7 +53,7 @@ const ClassDetailPage = () => {
   const addQueryParam = useInstitutionIdQueryParam();
 
   useEffect(() => {
-    if (username && className) {
+    if (username && className && institution?.id) {
       const params = {
         page: currentPage,
         class_name: className,
@@ -71,7 +71,7 @@ const ClassDetailPage = () => {
   }, [username, dispatch, currentPage, className, previousPage, institution]);
 
   useEffect(() => {
-    if (username) {
+    if (username && institution?.id) {
       const params = {
         class_id: classId,
         limit: false,

--- a/src/features/Classes/ClassesFilters/index.jsx
+++ b/src/features/Classes/ClassesFilters/index.jsx
@@ -67,7 +67,7 @@ const ClassesFilters = () => {
   };
 
   useEffect(() => {
-    if (instructorUserName) {
+    if (instructorUserName && institution?.id) {
       dispatch(fetchAllCourses(instructorUserName, { institution_id: institution?.id }));
       dispatch(fetchAllClassesData(instructorUserName, { institution_id: institution?.id }));
     }

--- a/src/features/Classes/ClassesPage/index.jsx
+++ b/src/features/Classes/ClassesPage/index.jsx
@@ -24,7 +24,7 @@ const ClassesPage = () => {
   const isLoading = classes.status === RequestStatus.LOADING;
 
   useEffect(() => {
-    if (instructorUserName) {
+    if (instructorUserName && institution?.id) {
       dispatch(getClasses(instructorUserName, {
         page: currentPage,
         limit: true,

--- a/src/features/Dashboard/DashboardPage/index.jsx
+++ b/src/features/Dashboard/DashboardPage/index.jsx
@@ -16,7 +16,7 @@ const DashboardPage = () => {
   const institution = useSelector((state) => state.main.institution);
 
   useEffect(() => {
-    if (userName) {
+    if (userName && institution?.id) {
       dispatch(fetchAllClassesData(userName, { institution_id: institution?.id }));
     }
   }, [userName, dispatch, institution]);

--- a/src/features/Dashboard/WeeklySchedule/index.jsx
+++ b/src/features/Dashboard/WeeklySchedule/index.jsx
@@ -38,7 +38,7 @@ const WeeklySchedule = () => {
   };
 
   useEffect(() => {
-    if (username) {
+    if (username && institution?.id) {
       dispatch(fetchAllClassesData(username, { institution_id: institution?.id }));
     }
   }, [username, dispatch, institution]);

--- a/src/features/Instructor/Profile/index.jsx
+++ b/src/features/Instructor/Profile/index.jsx
@@ -51,7 +51,7 @@ const Profile = () => {
   };
 
   useEffect(() => {
-    if (instructorEmail) {
+    if (instructorEmail && institution?.id) {
       dispatch(getClasses(instructorUserName, { institution_id: institution?.id, limit: true, page: currentPage }));
     }
 

--- a/src/features/Main/data/__test__/redux.test.jsx
+++ b/src/features/Main/data/__test__/redux.test.jsx
@@ -4,7 +4,7 @@ import { initializeMockApp } from '@edx/frontend-platform/testing';
 
 import { initializeStore } from 'store';
 import { executeThunk } from 'test-utils';
-import { fetchClassAuthorization } from 'features/Main/data';
+import { fetchInstitutionData } from 'features/Main/data';
 
 let axiosMock;
 let store;
@@ -28,54 +28,30 @@ describe('Main redux actions', () => {
     axiosMock.reset();
   });
 
-  describe('Classes', () => {
-    test('Should successful fetch classes data', async () => {
-      const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/`;
+  describe('Institutions', () => {
+    test('Successful fetch instructors data', async () => {
+      const institutionApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/institutions/?limit=false`;
       const mockResponse = [
         {
-          classId: 'ccx-v1:demo+demo1+2020+ccx1',
-          className: 'ccx 1',
-          masterCourseName: 'Demo Course 1',
-          instructors: [],
-          numberOfStudents: 0,
-          numberOfPendingStudents: 0,
-          maxStudents: 20,
-          startDate: '2024-01-23T21:50:51Z',
-          endDate: null,
+          id: 1,
+          name: 'Institution1',
+          shortName: 'Inst1',
+          active: true,
         },
       ];
-      const instructor = 'instructor01';
-      axiosMock.onGet(classesApiUrl)
+      axiosMock.onGet(institutionApiUrl)
         .reply(200, mockResponse);
 
-      expect(store.getState().main.classes.status)
-        .toEqual('initial');
+      expect(store.getState().main.institutions.status)
+        .toEqual('loading');
 
-      await executeThunk(fetchClassAuthorization(instructor), store.dispatch, store.getState);
+      await executeThunk(fetchInstitutionData(), store.dispatch, store.getState);
 
-      expect(store.getState().main.classes.data)
+      expect(store.getState().main.institutions.data)
         .toEqual(mockResponse);
 
-      expect(store.getState().main.classes.status)
+      expect(store.getState().main.institutions.status)
         .toEqual('success');
-    });
-
-    test('Should fail fetch classes data', async () => {
-      const classesApiUrl = `${process.env.COURSE_OPERATIONS_API_V2_BASE_URL}/classes/`;
-      const instructor = 'instructor01';
-      axiosMock.onGet(classesApiUrl)
-        .reply(500);
-
-      expect(store.getState().main.classes.status)
-        .toEqual('initial');
-
-      await executeThunk(fetchClassAuthorization(instructor), store.dispatch, store.getState);
-
-      expect(store.getState().main.classes.data)
-        .toEqual([]);
-
-      expect(store.getState().main.classes.status)
-        .toEqual('error');
     });
   });
 });

--- a/src/features/Main/data/index.js
+++ b/src/features/Main/data/index.js
@@ -1,2 +1,2 @@
 export { reducer } from 'features/Main/data/slice';
-export { fetchInstitutionData, fetchClassAuthorization } from 'features/Main/data/thunks';
+export { fetchInstitutionData } from 'features/Main/data/thunks';

--- a/src/features/Main/data/slice.js
+++ b/src/features/Main/data/slice.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit';
-import { initialStateService, RequestStatus } from 'features/constants';
+import { initialStateService } from 'features/constants';
 
 const initialState = {
   activeTab: 'dashboard',
@@ -9,11 +9,6 @@ const initialState = {
     ...initialStateService,
   },
   username: '',
-  classes: {
-    data: [],
-    status: RequestStatus.INITIAL,
-    error: null,
-  },
 };
 
 export const mainSlice = createSlice({
@@ -33,16 +28,6 @@ export const mainSlice = createSlice({
     updateUsername: (state, { payload }) => {
       state.username = payload;
     },
-    updateRequestClassStatus: (state, { payload }) => {
-      state.classes.status = payload;
-    },
-    updateClasses: (state, { payload }) => {
-      state.classes.data = payload;
-      state.classes.status = RequestStatus.SUCCESS;
-    },
-    updateClassError: (state, { payload }) => {
-      state.classes.error = payload;
-    },
   },
 });
 
@@ -51,9 +36,6 @@ export const {
   updateSelectedInstitutions,
   updateActiveTab,
   updateUsername,
-  updateRequestClassStatus,
-  updateClasses,
-  updateClassError,
 } = mainSlice.actions;
 
 export const { reducer } = mainSlice;

--- a/src/features/Main/data/thunks.js
+++ b/src/features/Main/data/thunks.js
@@ -4,11 +4,7 @@ import { sortAlphabetically } from 'react-paragon-topaz';
 import { getInstitutionName } from 'features/Main/data/api';
 import {
   updateSelectedInstitutions,
-  updateRequestClassStatus,
-  updateClasses,
-  updateClassError,
 } from 'features/Main/data/slice';
-import { getClassesByInstructor } from 'features/Common/data/api';
 import { RequestStatus } from 'features/constants';
 
 function fetchInstitutionData() {
@@ -25,34 +21,6 @@ function fetchInstitutionData() {
   };
 }
 
-/* Fetch all classes by instructor username to allow authorization in portal
- *
- * @param {string} username - The username of the instructor.
- *
- * @returns {Promise} - A promise that resolves to the response from the API.
- */
-function fetchClassAuthorization(username) {
-  return async (dispatch) => {
-    dispatch(updateRequestClassStatus(RequestStatus.LOADING));
-
-    try {
-      const params = {
-        limit: false,
-      };
-      const response = camelCaseObject(
-        await getClassesByInstructor(username, params),
-      );
-      dispatch(updateClasses(response.data));
-      dispatch(updateRequestClassStatus(RequestStatus.SUCCESS));
-    } catch (error) {
-      dispatch(updateRequestClassStatus(RequestStatus.ERROR));
-      dispatch(updateClassError(error?.customAttributes?.httpErrorStatus));
-      logError(error);
-    }
-  };
-}
-
 export {
   fetchInstitutionData,
-  fetchClassAuthorization,
 };

--- a/src/features/Main/index.jsx
+++ b/src/features/Main/index.jsx
@@ -29,7 +29,7 @@ import Profile from 'features/Instructor/Profile';
 import UnauthorizedPage from 'features/Main/UnauthorizedPage';
 
 import { fetchInstructorProfile } from 'features/Instructor/data';
-import { fetchInstitutionData, fetchClassAuthorization } from 'features/Main/data/thunks';
+import { fetchInstitutionData } from 'features/Main/data/thunks';
 import { updateSelectedInstitution } from 'features/Main/data/slice';
 
 import { INSTITUTION_QUERY_ID, RequestStatus } from 'features/constants';
@@ -45,12 +45,11 @@ const Main = () => {
 
   const institutions = useSelector((state) => state.main.institutions.data);
   const institution = useSelector((state) => state.main.institution);
-  const username = useSelector((state) => state.main.username);
-  const classes = useSelector((state) => state.main.classes);
 
   const bannerText = getConfig().MAINTENANCE_BANNER_TEXT || '';
 
-  const isLoadingClasses = classes.status === RequestStatus.LOADING || classes.status === RequestStatus.INITIAL;
+  const statusInstitutions = useSelector((state) => state.main.institution.status);
+  const isLoadingInstitutions = statusInstitutions === RequestStatus.LOADING;
   const isAuthorizedUser = roles.includes(USER_ROLES.INSTRUCTOR);
 
   const searchParams = new URLSearchParams(location.search);
@@ -61,13 +60,7 @@ const Main = () => {
   }, [dispatch]);
 
   useEffect(() => {
-    if (username) {
-      dispatch(fetchClassAuthorization(username));
-    }
-  }, [dispatch, username]);
-
-  useEffect(() => {
-    if (instructorEmail) {
+    if (instructorEmail && institution?.id) {
       dispatch(fetchInstructorProfile(instructorEmail, { institution_id: institution?.id }));
     }
   }, [instructorEmail, dispatch, institution]);
@@ -97,7 +90,7 @@ const Main = () => {
         <Banner variant="warning" iconWarning text={bannerText} />
       )}
       <main className="d-flex pageWrapper">
-        {isLoadingClasses && (
+        {isLoadingInstitutions && (
           <div className="w-100 h-100 d-flex justify-content-center align-items-center mt-4">
             <Spinner
               animation="border"
@@ -106,8 +99,8 @@ const Main = () => {
             />
           </div>
         )}
-        {!isLoadingClasses && !isAuthorizedUser && <UnauthorizedPage />}
-        {!isLoadingClasses && isAuthorizedUser && (
+        {!isLoadingInstitutions && !isAuthorizedUser && <UnauthorizedPage />}
+        {!isLoadingInstitutions && isAuthorizedUser && (
           <>
             <Sidebar />
             <Container>

--- a/src/features/Students/StudentsDetails/index.jsx
+++ b/src/features/Students/StudentsDetails/index.jsx
@@ -74,12 +74,14 @@ const StudentsDetails = () => {
   };
 
   useEffect(() => {
-    const studentParams = {
-      learner_email: decodedEmail,
-      institution_id: institution?.id,
-    };
+    if (institution?.id) {
+      const studentParams = {
+        learner_email: decodedEmail,
+        institution_id: institution?.id,
+      };
 
-    dispatch(fetchStudentProfile(instructorUserName, studentParams));
+      dispatch(fetchStudentProfile(instructorUserName, studentParams));
+    }
 
     return () => {
       dispatch(resetStudent());
@@ -88,7 +90,7 @@ const StudentsDetails = () => {
   }, [dispatch, instructorUserName, decodedEmail, institution?.id]);
 
   useEffect(() => {
-    if (instructorUserName) {
+    if (instructorUserName && institution?.id) {
       const requestParams = {
         institution_id: institution?.id,
         limit: true,

--- a/src/features/Students/StudentsFilters/index.jsx
+++ b/src/features/Students/StudentsFilters/index.jsx
@@ -84,7 +84,7 @@ const StudentsFilters = () => {
   };
 
   useEffect(() => {
-    if (instructorUserName) {
+    if (instructorUserName && institution?.id) {
       dispatch(fetchAllCourses(instructorUserName, { institution_id: institution?.id }));
     }
   }, [dispatch, instructorUserName, institution]);

--- a/src/features/Students/StudentsPage/index.jsx
+++ b/src/features/Students/StudentsPage/index.jsx
@@ -22,7 +22,7 @@ const StudentsPage = () => {
   const [currentPage, setCurrentPage] = useState(initialPage);
 
   useEffect(() => {
-    if (username) {
+    if (username && institution?.id) {
       dispatch(fetchStudentsData(username, {
         page: currentPage,
         institution_id: institution?.id,


### PR DESCRIPTION
### Description
After enable institution service for instructor and send the new param instructor_portal that will retrieve only the information if the instructor is assigned to an institution, in the first load of the page the info is not loaded correctly because is not sent the institution id.

### Changes made
Fix first call services without institution id 
Remove deprecated classes call used before to verify authorization in portal
Update tests

### How to test
Clone the Institution Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1990/

Have last changes of course_operations repo