### PR TITLE
PADV-2203 chore: point lab dashboard button to skillable and xtreme labs api

### DIFF
--- a/src/features/Classes/ClassDetailPage/__test__/index.test.jsx
+++ b/src/features/Classes/ClassDetailPage/__test__/index.test.jsx
@@ -64,7 +64,7 @@ const mockStore = {
           maxStudents: 200,
           startDate: '2024-04-03T00:00:00Z',
           endDate: null,
-          labSummaryUrl: 'https: //',
+          labSummaryTag: 'skillable-dashboard',
         },
       ],
     },
@@ -118,7 +118,7 @@ describe('ClassDetailPage', () => {
     fireEvent.click(dropdownToggle);
 
     expect(component.getByText('Gradebook')).toBeInTheDocument();
-    expect(component.getByText('Lab summary')).toBeInTheDocument();
+    expect(component.getByText('Lab Dashboard')).toBeInTheDocument();
   });
 
   test('opens Gradebook in a new tab', async () => {

--- a/src/features/Classes/ClassDetailPage/index.jsx
+++ b/src/features/Classes/ClassDetailPage/index.jsx
@@ -8,9 +8,11 @@ import { Button } from 'react-paragon-topaz';
 import {
   Container,
   Pagination,
+  Toast,
 } from '@edx/paragon';
 
-import { useInstitutionIdQueryParam } from 'hooks';
+import { useInstitutionIdQueryParam, useToast } from 'hooks';
+import { fetchLabSummaryLink } from 'features/Classes/data/thunks';
 import InstructorCard from 'features/Classes/ClassDetailPage/InstructorCard';
 import EnrollStudent from 'features/Classes/EnrollStudent';
 
@@ -36,6 +38,12 @@ const ClassDetailPage = () => {
   const username = useSelector((state) => state.main.username);
   const institution = useSelector((state) => state.main.institution);
   const [classInfo] = useSelector((state) => state.common.allClasses?.data);
+  const {
+    isVisible,
+    message,
+    showToast,
+    hideToast,
+  } = useToast();
 
   // Set to 'true' by default to maintain normal behavior.
   const enableEnrollmentPrivilege = getConfig()?.SHOW_INSTRUCTOR_FEATURES || true;
@@ -94,8 +102,10 @@ const ClassDetailPage = () => {
     window.open(`${gradebookUrl}/gradebook/${classId}`, '_blank', 'noopener,noreferrer');
   };
 
-  const handleLabButton = () => {
-    window.open(classInfo?.labSummaryUrl, '_blank', 'noopener,noreferrer');
+  const handleLabSummary = () => {
+    dispatch(fetchLabSummaryLink(classId, classInfo?.labSummaryTag, (dashboardMessage) => {
+      showToast(dashboardMessage);
+    }));
   };
 
   const extraOptions = [
@@ -106,15 +116,23 @@ const ClassDetailPage = () => {
       visible: true,
     },
     {
-      handleClick: handleLabButton,
+      handleClick: handleLabSummary,
       iconSrc: <i className="fa-regular fa-rectangle-list mr-3" />,
-      label: 'Lab summary',
-      visible: !!classInfo?.labSummaryUrl,
+      label: 'Lab Dashboard',
+      visible: !!classInfo?.labSummaryTag,
     },
   ];
 
   return (
     <>
+      <Toast
+        onClose={hideToast}
+        show={isVisible}
+        className="toast-message"
+        data-testid="toast-message"
+      >
+        {message}
+      </Toast>
       {!classInfo && (
         <Container size="xl" className="px-4 mt-3 page-content-container d-flex justify-content-center">
           <p>You must be an instructor in this class to see the information.</p>

--- a/src/features/Classes/data/__test__/api.test.js
+++ b/src/features/Classes/data/__test__/api.test.js
@@ -1,5 +1,5 @@
 import {
-  handleEnrollments, getMessages,
+  handleEnrollments, getMessages, handleSkillableDashboard, handleXtremeLabsDashboard,
 } from 'features/Classes/data/api';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
@@ -54,6 +54,58 @@ describe('getMessages', () => {
     expect(httpClientMock.get).toHaveBeenCalledTimes(1);
     expect(httpClientMock.get).toHaveBeenCalledWith(
       'http://localhost:18000/pearson_course_operation/api/messages/get-messages/',
+    );
+  });
+});
+
+describe('handleSkillableDashboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should call getAuthenticatedHttpClient with the correct parameters', () => {
+    const httpClientMock = {
+      post: jest.fn().mockResolvedValue({}),
+    };
+    const courseId = 'course456';
+
+    getAuthenticatedHttpClient.mockReturnValue(httpClientMock);
+
+    handleSkillableDashboard(courseId);
+
+    expect(getAuthenticatedHttpClient).toHaveBeenCalledTimes(1);
+    expect(getAuthenticatedHttpClient).toHaveBeenCalledWith();
+
+    expect(httpClientMock.post).toHaveBeenCalledTimes(1);
+    expect(httpClientMock.post).toHaveBeenCalledWith(
+      'http://localhost:18000/skillable_plugin/course-tab/api/v1/instructor-dashboard-launch/',
+      { class_id: courseId },
+    );
+  });
+});
+
+describe('handleXtremeLabsDashboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should call getAuthenticatedHttpClient with the correct parameters', () => {
+    const httpClientMock = {
+      post: jest.fn().mockResolvedValue({}),
+    };
+    const courseId = 'course789';
+
+    getAuthenticatedHttpClient.mockReturnValue(httpClientMock);
+
+    handleXtremeLabsDashboard(courseId);
+
+    expect(getAuthenticatedHttpClient).toHaveBeenCalledTimes(1);
+    expect(getAuthenticatedHttpClient).toHaveBeenCalledWith();
+
+    expect(httpClientMock.post).toHaveBeenCalledTimes(1);
+    expect(httpClientMock.post).toHaveBeenCalledWith(
+      'http://localhost:18000/xtreme_labs_plugin/course-tab/api/v1/instructor-dashboard-launch/',
+      { class_id: courseId },
     );
   });
 });

--- a/src/features/Classes/data/api.js
+++ b/src/features/Classes/data/api.js
@@ -16,7 +16,27 @@ function getMessages() {
   );
 }
 
+function handleSkillableDashboard(courseId) {
+  const SKILLABLE_API_URL = `${getConfig().LMS_BASE_URL}/skillable_plugin/course-tab/api/v1`;
+
+  return getAuthenticatedHttpClient().post(
+    `${SKILLABLE_API_URL}/instructor-dashboard-launch/`,
+    { class_id: courseId },
+  );
+}
+
+function handleXtremeLabsDashboard(courseId) {
+  const XTREME_LABS_API_URL = `${getConfig().LMS_BASE_URL}/xtreme_labs_plugin/course-tab/api/v1`;
+
+  return getAuthenticatedHttpClient().post(
+    `${XTREME_LABS_API_URL}/instructor-dashboard-launch/`,
+    { class_id: courseId },
+  );
+}
+
 export {
   handleEnrollments,
   getMessages,
+  handleSkillableDashboard,
+  handleXtremeLabsDashboard,
 };

--- a/src/features/Classes/data/thunks.js
+++ b/src/features/Classes/data/thunks.js
@@ -7,6 +7,7 @@ import {
   updateClassesRequestStatus,
 } from 'features/Classes/data/slice';
 import { getClassesByInstructor } from 'features/Common/data/api';
+import { handleSkillableDashboard, handleXtremeLabsDashboard } from 'features/Classes/data/api';
 
 import { RequestStatus } from 'features/constants';
 
@@ -30,6 +31,38 @@ function getClasses(userName, options = {}) {
   };
 }
 
+function fetchLabSummaryLink(classId, labSummaryTag, showToast) {
+  return async () => {
+    try {
+      const labDashboardOptions = {
+        'skillable-dashboard': handleSkillableDashboard,
+        'xtreme-labs-dashboard': handleXtremeLabsDashboard,
+      };
+
+      const fetchDashboard = labDashboardOptions[labSummaryTag];
+
+      if (!fetchDashboard) {
+        throw new Error(`Unsupported lab summary tag: ${labSummaryTag}`);
+      }
+
+      const response = await fetchDashboard(classId);
+
+      const url = response?.data?.url || response?.data?.redirect_to;
+
+      if (url) {
+        window.open(url, '_blank', 'noopener,noreferrer');
+      } else {
+        const errorMessage = response?.data?.message || response?.data?.error;
+        throw new Error(errorMessage);
+      }
+    } catch (error) {
+      showToast(error.message || 'An unexpected error occurred.');
+      logError(error);
+    }
+  };
+}
+
 export {
   getClasses,
+  fetchLabSummaryLink,
 };

--- a/src/hooks/__test__/index.test.jsx
+++ b/src/hooks/__test__/index.test.jsx
@@ -1,7 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 
 import { renderWithProviders } from 'test-utils';
-import { useInstitutionIdQueryParam } from 'hooks';
+import { useInstitutionIdQueryParam, useToast } from 'hooks';
 import { INSTITUTION_QUERY_ID } from 'features/constants';
 
 describe('useInstitutionIdQueryParam', () => {
@@ -47,5 +47,40 @@ describe('useInstitutionIdQueryParam', () => {
     });
 
     expect(result.current('http://example.com?foo=bar')).toBe(`http://example.com?foo=bar&${INSTITUTION_QUERY_ID}=${institutionId}`);
+  });
+});
+
+describe('useToast', () => {
+  test('Should initialize with default toast state', () => {
+    const { result } = renderHook(() => useToast());
+
+    expect(result.current.isVisible).toBe(false);
+    expect(result.current.message).toBe('');
+  });
+
+  test('Should update toast state when showToast is called', () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.showToast('Test message');
+    });
+
+    expect(result.current.isVisible).toBe(true);
+    expect(result.current.message).toBe('Test message');
+  });
+
+  test('Should reset toast state when hideToast is called', () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.showToast('Test message');
+    });
+
+    act(() => {
+      result.current.hideToast();
+    });
+
+    expect(result.current.isVisible).toBe(false);
+    expect(result.current.message).toBe('');
   });
 });

--- a/src/hooks/index.jsx
+++ b/src/hooks/index.jsx
@@ -1,4 +1,5 @@
 import { useSelector } from 'react-redux';
+import { useState } from 'react';
 
 import { INSTITUTION_QUERY_ID } from 'features/constants';
 
@@ -15,4 +16,36 @@ export const useInstitutionIdQueryParam = () => {
   };
 
   return addQueryParam;
+};
+
+/**
+ * Custom hook to manage toast notifications
+ * @returns {Object} Toast state and methods
+ */
+export const useToast = () => {
+  const [toast, setToast] = useState({
+    isVisible: false,
+    message: '',
+  });
+
+  const showToast = (message) => {
+    setToast({
+      isVisible: true,
+      message,
+    });
+  };
+
+  const hideToast = () => {
+    setToast({
+      isVisible: false,
+      message: '',
+    });
+  };
+
+  return {
+    isVisible: toast.isVisible,
+    message: toast.message,
+    showToast,
+    hideToast,
+  };
 };


### PR DESCRIPTION
## Description

This PR point Lab summary (now renamed Lab Dashboard) to the skillable and Xtreme Lab dashboard directly. From the backend, we retrieve the "skillable-dashboad" or "xtreme-labs-dashboard" tag, that indicates which endpoint is required to consume, to generate the URL that will be used to redirect the user, to the respective external portal.

In case the request fail retrieving the URL, a Toast is used to show the response error message.

## How to test

1. Use the changes in this branch and run "npm start"
2. Run your local openedx environment
3. Use the brabch in this PR: https://github.com/Pearson-Advance/course_operations/pull/359 to retrieve the lab summary tag
4. Go to the portal, in a class details, and click on the Lab Dashboard button
![image](https://github.com/user-attachments/assets/d0ce0047-7489-4d54-b422-d5c410375a62)
5. For "skillable-dashboad" or "xtreme-labs-dashboard" tag, will open a new window to the external dashboard if the request got a URL. Examples:

* Skillable dashboard
![image](https://github.com/user-attachments/assets/845d98bb-21fd-4b46-a8a0-3a5e83b637a6)

* xtreme labs dashboard
![image](https://github.com/user-attachments/assets/c308b010-671c-4598-b87e-17b972fb39c8)


6. In case skillable or xtreme labs are not available in other course settings for the class, the button "Lab Dashboard" will not be rendering in the dropdown

## Jira issue

* https://agile-jira.pearson.com/browse/PADV-2203