### PR TITLE
PADV-2344 feat: remove tz from class event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-intl": "^5.25.1",
-        "react-paragon-topaz": "^1.29.0",
+        "react-paragon-topaz": "^1.30.0",
         "react-redux": "7.2.9",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
@@ -15351,9 +15351,9 @@
       }
     },
     "node_modules/react-paragon-topaz": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.29.0.tgz",
-      "integrity": "sha512-W02pA2y2XG0dnA1fgLZvHB2GKn4Ced42noEJFIa898O6TWgdbciSlZoX4PBZhB0WMT6Y/wuDwdLoePs32WXE7g==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.30.0.tgz",
+      "integrity": "sha512-zwoLzgk5qGzGIeX047Yq8hHyax9Z8MeD2LZ8l9h7ebAkuWKs7Snfdj9Z6RJZn0ZDvfH8sdZf55a/Cw8haA7Agg==",
       "dependencies": {
         "@babel/runtime": "7.25.6",
         "@edx/frontend-platform": "4.5.1",
@@ -30528,9 +30528,9 @@
       }
     },
     "react-paragon-topaz": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.29.0.tgz",
-      "integrity": "sha512-W02pA2y2XG0dnA1fgLZvHB2GKn4Ced42noEJFIa898O6TWgdbciSlZoX4PBZhB0WMT6Y/wuDwdLoePs32WXE7g==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.30.0.tgz",
+      "integrity": "sha512-zwoLzgk5qGzGIeX047Yq8hHyax9Z8MeD2LZ8l9h7ebAkuWKs7Snfdj9Z6RJZn0ZDvfH8sdZf55a/Cw8haA7Agg==",
       "requires": {
         "@babel/runtime": "7.25.6",
         "@edx/frontend-platform": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-intl": "^5.25.1",
-    "react-paragon-topaz": "^1.29.0",
+    "react-paragon-topaz": "^1.30.0",
     "react-redux": "7.2.9",
     "react-router": "5.2.1",
     "react-router-dom": "5.3.0",

--- a/src/features/Instructor/Availability/index.jsx
+++ b/src/features/Instructor/Availability/index.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { startOfMonth, endOfMonth, endOfDay } from 'date-fns';
-import { Button, CalendarExpanded, AddEventModal } from 'react-paragon-topaz';
+import {
+  Button, CalendarExpanded, AddEventModal, parseUTCDateWithoutTZ,
+} from 'react-paragon-topaz';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { fetchEventsData } from 'features/Instructor/data';
@@ -137,16 +139,26 @@ const Availability = () => {
   }, [rangeDates, dispatch, institution]);
 
   useEffect(() => {
-    if (events.length > 0) {
-      const list = events?.map(event => ({
+    if (!Array.isArray(events) || events.length === 0) { return; }
+
+    const list = events.map(event => {
+      const { start, end, isClass } = event;
+
+      if (isClass) {
+        return {
+          ...event,
+          start: parseUTCDateWithoutTZ(start),
+          end: endOfDay(parseUTCDateWithoutTZ(end)),
+        };
+      }
+
+      return {
         ...event,
-        start: new Date(event.start),
-        end: new Date(event.end),
-      }));
-      setEventsList(list);
-    } else {
-      setEventsList([]);
-    }
+        start: new Date(start),
+        end: new Date(end),
+      };
+    });
+    setEventsList(list);
   }, [events]);
 
   return (


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2344

### Description
In the calendar availability the classes events begin one day before the date defined. This behavior is related to timezone, as the calendar component needs a date object, when the browser convert from string to date it take the local timezone. So to fix it, we have to remove the hour from the utc string and make the date with the year, month and day, this is done in the library: https://github.com/Pearson-Advance/react-paragon-topaz-library/pull/61

### Changes made
Update react-topaz library version
Change start and end date to be without tz if is a class

### Screenshoot
![Screenshot from 2025-05-14 19-37-02](https://github.com/user-attachments/assets/25550298-20c6-4b17-abf0-e164281538e7)
![Screenshot from 2025-05-14 19-37-24](https://github.com/user-attachments/assets/5c2b0c20-b214-4146-829b-342f3e24cfd4)

### How to test
Clone the Instructors Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1990/