### PR TITLE
feat: Add CP link in instructor portal depending of role

### DIFF
--- a/src/features/Main/Sidebar/__test__/index.test.jsx
+++ b/src/features/Main/Sidebar/__test__/index.test.jsx
@@ -4,6 +4,7 @@ import { fireEvent } from '@testing-library/react';
 
 import { Sidebar } from 'features/Main/Sidebar';
 import { renderWithProviders } from 'test-utils';
+import * as paragonTopaz from 'react-paragon-topaz';
 
 const mockHistoryPush = jest.fn();
 
@@ -15,6 +16,17 @@ jest.mock('react-router', () => ({
       pathname: '/',
     },
   }),
+}));
+
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(() => ({
+    INSTITUTION_PORTAL_PATH: 'https://institution.example.com',
+  })),
+}));
+
+jest.mock('react-paragon-topaz', () => ({
+  ...jest.requireActual('react-paragon-topaz'),
+  getUserRoles: jest.fn(() => (['INSTRUCTOR'])),
 }));
 
 describe('Sidebar', () => {
@@ -46,5 +58,17 @@ describe('Sidebar', () => {
     expect(profileButton).toHaveClass('active');
 
     expect(mockHistoryPush).toHaveBeenCalledWith('/my-profile');
+  });
+
+  test('should render Institution Portal item if has role', () => {
+    paragonTopaz.getUserRoles.mockReturnValue(['INSTRUCTOR', 'INSTITUTION_ADMIN']);
+
+    const { getByText } = renderWithProviders(
+      <Sidebar />,
+    );
+
+    const portalLink = getByText('Skilling Administrator');
+
+    expect(portalLink).toBeInTheDocument();
   });
 });

--- a/src/features/Main/Sidebar/index.jsx
+++ b/src/features/Main/Sidebar/index.jsx
@@ -1,17 +1,20 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
+import { getConfig } from '@edx/frontend-platform';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   Sidebar as SidebarBase,
   MenuSection,
   MenuItem,
   SIDEBAR_HELP_ITEMS,
+  getUserRoles,
+  USER_ROLES,
 } from 'react-paragon-topaz';
 
 import { useInstitutionIdQueryParam } from 'hooks';
 import { updateActiveTab } from 'features/Main/data/slice';
 
-const menuItems = [
+const baseItems = [
   {
     link: 'dashboard',
     label: 'Home',
@@ -37,8 +40,24 @@ const menuItems = [
 export const Sidebar = () => {
   const history = useHistory();
   const dispatch = useDispatch();
+  const roles = getUserRoles();
   const activeTab = useSelector((state) => state.main.activeTab);
   const currentSelection = activeTab.replace(/\?institutionId=\d+/, '');
+  const menuItems = [...baseItems];
+  const institutionPortalPath = getConfig().INSTITUTION_PORTAL_PATH || '';
+  const adminRoles = [USER_ROLES.GLOBAL_STAFF, USER_ROLES.INSTITUTION_ADMIN];
+
+  if (adminRoles.some(role => roles.includes(role)) && institutionPortalPath.length > 0) {
+    menuItems.push({
+      link: 'institution-portal',
+      as: 'a',
+      href: institutionPortalPath,
+      label: 'Skilling Administrator',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      icon: <i className="fa-regular fa-user-gear" />,
+    });
+  }
 
   const handleTabClick = (tabName) => {
     dispatch(updateActiveTab(tabName));
@@ -51,16 +70,34 @@ export const Sidebar = () => {
     <SidebarBase>
       <MenuSection>
         {
-            menuItems.map(({ link, label, icon }) => (
-              <MenuItem
-                key={link}
-                title={label}
-                path={addQueryParam(link)}
-                active={currentSelection === link}
-                onClick={handleTabClick}
-                icon={icon}
-              />
-            ))
+           menuItems.map(({
+             link, label, icon, as, href, target, rel,
+           }) => {
+             if (as === 'a') {
+               return (
+                 <MenuItem
+                   key={link}
+                   title={label}
+                   as={as}
+                   href={href}
+                   icon={icon}
+                   target={target}
+                   rel={rel}
+                 />
+               );
+             }
+
+             return (
+               <MenuItem
+                 key={link}
+                 title={label}
+                 path={addQueryParam(link)}
+                 active={currentSelection === link}
+                 onClick={handleTabClick}
+                 icon={icon}
+               />
+             );
+           })
         }
       </MenuSection>
       <MenuSection title="Help and support">


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-2252

### Description
Add link to CP portal when the user has an admin role

### Changes made
Include link to CP portal when user has an admin role
If the item is a link element will render different the menu item in the sidebar
update test

### Screenshoot
![Screenshot from 2025-06-06 12-18-08](https://github.com/user-attachments/assets/a213ac44-c726-40a9-941b-b08349c2ad52)

### How to test
Clone the Instructors Portal MFE
Run npm install.
Run npm run start
Go to http://localhost:1990/
Required:
Go to site configuration, in MFE_CONFIG add this variable:
"INSTITUTION_PORTAL_PATH": "/admin",

Note: Locally it won't open the CP because is different port but you will see that will open in the same base url and then the institution portal path defined