### PR TITLE
feat: first name instead of user name in dashboard view

### DIFF
--- a/src/features/Dashboard/DashboardPage/__test__/index.test.jsx
+++ b/src/features/Dashboard/DashboardPage/__test__/index.test.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
-import DashboardPage from 'features/Dashboard/DashboardPage';
 import '@testing-library/jest-dom/extend-expect';
 import { renderWithProviders } from 'test-utils';
 import { MemoryRouter, Route } from 'react-router-dom';
+
+import { AppContext } from '@edx/frontend-platform/react';
+
+import DashboardPage from 'features/Dashboard/DashboardPage';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
@@ -32,19 +35,30 @@ describe('DashboardPage component', () => {
     },
   };
 
+  const authenticatedUser = {
+    name: 'Sam Smith',
+    email: 'test@example.com',
+  };
+
+  const config = {
+    LMS_BASE_URL: 'http://localhost:1990',
+  };
+
   const component = renderWithProviders(
-    <MemoryRouter initialEntries={['/dashboard']}>
-      <Route path="/dashboard">
-        <DashboardPage />
-      </Route>
-    </MemoryRouter>,
+    <AppContext.Provider value={{ authenticatedUser, config }}>
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Route path="/dashboard">
+          <DashboardPage />
+        </Route>
+      </MemoryRouter>,
+    </AppContext.Provider>,
     { preloadedState: mockStore },
   );
 
   test('renders components', () => {
     const { getByText } = component;
 
-    expect(getByText('Welcome User')).toBeInTheDocument();
+    expect(getByText('Welcome Sam')).toBeInTheDocument();
     expect(getByText('Class schedule')).toBeInTheDocument();
     expect(getByText('No classes scheduled at this time')).toBeInTheDocument();
   });

--- a/src/features/Dashboard/DashboardPage/index.jsx
+++ b/src/features/Dashboard/DashboardPage/index.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { getConfig } from '@edx/frontend-platform';
+import { AppContext } from '@edx/frontend-platform/react';
 import { Container, Col, Row } from '@edx/paragon';
 
 import WeeklySchedule from 'features/Dashboard/WeeklySchedule';
@@ -13,6 +14,7 @@ import { isInvalidUserOrInstitution } from 'helpers';
 const DashboardPage = () => {
   const dispatch = useDispatch();
   const userName = useSelector((state) => state.main.username);
+  const { authenticatedUser: { name } } = useContext(AppContext);
   const imageDashboard = getConfig().IMAGE_DASHBOARD_INSTRUCTORS_URL;
   const institution = useSelector((state) => state.main.institution);
 
@@ -25,7 +27,7 @@ const DashboardPage = () => {
   return (
     <Container size="xl" className="px-4 pt-3">
       <h2 className="title-page mt-3 mb-3">
-        {`Welcome ${userName}` }
+        {`Welcome ${name?.split?.(' ')[0] || userName}` }
       </h2>
       <Row className="schedule-section">
         <Col lg="9" xs="12">


### PR DESCRIPTION
# Description
This update modifies the dashboard view to display the user's first name instead of their username. This change improves personalization and enhances the overall user experience.


## How to test
Go to `/dashboard`

You should be able to see the first name of the current user, if is not defined the username will be displayed in its place