### PR TITLE
fix: reorder 'Students enrolled' column in ClassesPage

### DIFF
--- a/src/features/Classes/ClassesPage/columns.jsx
+++ b/src/features/Classes/ClassesPage/columns.jsx
@@ -59,12 +59,12 @@ const columns = [
     accessor: 'minStudentsAllowed',
   },
   {
-    Header: 'Students enrolled',
-    accessor: 'numberOfStudents',
-  },
-  {
     Header: 'Max',
     accessor: 'maxStudents',
+  },
+  {
+    Header: 'Students enrolled',
+    accessor: 'numberOfStudents',
   },
   {
     Header: '',


### PR DESCRIPTION
This pull request makes a minor adjustment to the ordering of columns in the `columns` array in `columns.jsx`, moving the "Students enrolled" column to a position after "Max" instead of after "Min". No other changes are included.

- Reordered the "Students enrolled" column to appear after the "Max" column in the `columns` array in `columns.jsx`.

### How to test
1. Run a Pearson environment with Tutor or devstack
2. Clone this repo and switch to the branch of this PR
3. Start the instructors-portal MFE
4. Verify the table has the new required structure

    <img width="1870" height="1132" alt="image" src="https://github.com/user-attachments/assets/77847f54-cb9f-433d-962c-502a0813c048" />

### Additional Information

- [Ticket 1918](https://pearson.atlassian.net/browse/PADV-1918?atlOrigin=eyJpIjoiZmM0Y2Q5Mjk0YWQ4NDZkNmE1ZDk1NGY0MGQ5ZmQzZjYiLCJwIjoiaiJ9)