### PR TITLE
PADV-2792 - "Exam Ready" , "Last Practice Exam" & "EPP Days Left" Columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-intl": "^5.25.1",
-        "react-paragon-topaz": "1.38.0",
+        "react-paragon-topaz": "1.40.1",
         "react-redux": "7.2.9",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",
@@ -15338,9 +15338,9 @@
       }
     },
     "node_modules/react-paragon-topaz": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.38.0.tgz",
-      "integrity": "sha512-8aRPx+zYTWVHWCggWQggnYa//Y5gBOZ0Ov0UodeYqmI161RBDHdlx+veN5v8nyl67mUVtlU+o5KLpyRKYmK16w==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.40.1.tgz",
+      "integrity": "sha512-tSYxg9YxdaACM5pzNet8J965e60QKQ3RAoR34xG3Asa904f0Cb+WPOb9dJMFcuR/hDpIbiD5kYRI7H0NiB6fRA==",
       "dependencies": {
         "@babel/runtime": "7.25.6",
         "@edx/frontend-platform": "4.5.1",
@@ -30509,9 +30509,9 @@
       }
     },
     "react-paragon-topaz": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.38.0.tgz",
-      "integrity": "sha512-8aRPx+zYTWVHWCggWQggnYa//Y5gBOZ0Ov0UodeYqmI161RBDHdlx+veN5v8nyl67mUVtlU+o5KLpyRKYmK16w==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/react-paragon-topaz/-/react-paragon-topaz-1.40.1.tgz",
+      "integrity": "sha512-tSYxg9YxdaACM5pzNet8J965e60QKQ3RAoR34xG3Asa904f0Cb+WPOb9dJMFcuR/hDpIbiD5kYRI7H0NiB6fRA==",
       "requires": {
         "@babel/runtime": "7.25.6",
         "@edx/frontend-platform": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-intl": "^5.25.1",
-    "react-paragon-topaz": "1.38.0",
+    "react-paragon-topaz": "1.40.1",
     "react-redux": "7.2.9",
     "react-router": "5.2.1",
     "react-router-dom": "5.3.0",

--- a/src/assets/colors.scss
+++ b/src/assets/colors.scss
@@ -7,6 +7,8 @@ $primary-dark: #003057;
 //Basic colors
 $white: #fefefe;
 
+$blue-50: #a6dff7;
+
 //Gray
 $gray-20: #dfe1e1;
 $gray-30: #d3d3d3;

--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -2,3 +2,8 @@
 $border-radius-1: 0.375rem;
 
 $custom-switch-indicator-checked-bg: $primary;
+
+$overlay-bg: #2b2b2b;
+$overlay-shadow: rgba(0, 0, 0, 0.25);
+
+$overlay-text: $white;

--- a/src/features/Classes/ClassDetailPage/columns.jsx
+++ b/src/features/Classes/ClassDetailPage/columns.jsx
@@ -4,9 +4,15 @@ import {
   Dropdown,
   IconButton,
   Icon,
+  Overlay,
 } from '@edx/paragon';
 import { MoreHoriz } from '@edx/paragon/icons';
-import { Badge, STUDENT_STATUS_VARIANTS } from 'react-paragon-topaz';
+import {
+  Badge,
+  STUDENT_STATUS_VARIANTS,
+  ProgressSteps,
+  formatUTCDate,
+} from 'react-paragon-topaz';
 import { Link } from 'react-router-dom';
 import { getConfig } from '@edx/frontend-platform';
 
@@ -77,9 +83,67 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
     },
   },
   {
-    Header: 'Exam ready',
+    Header: 'Exam Ready',
     accessor: 'examReady',
-    Cell: ({ row }) => <span>{row.values.examReady ? 'Yes' : 'No'}</span>,
+    Cell: ({ row }) => (<ProgressSteps status={row.values.examReady.status.toLowerCase()} />),
+  },
+  {
+    Header: 'Last exam date',
+    accessor: 'examReady.lastExamDate',
+    Cell: ({ row }) => {
+      const lastExamDate = row.values.examReady.lastExamDate
+        ? formatUTCDate(row.values.examReady.lastExamDate, 'MM/dd/yy')
+        : '--';
+      return <span>{lastExamDate}</span>;
+    },
+  },
+  {
+    Header: () => {
+      const [show, setShow] = React.useState(false);
+      const target = React.useRef(null);
+
+      return (
+        <>
+          <span
+            ref={target}
+            className="epp-header"
+            onMouseEnter={() => setShow(true)}
+            onMouseLeave={() => setShow(false)}
+          >
+            Epp days left
+            <i className="fa-regular fa-circle-info ml-1" />
+          </span>
+
+          <Overlay target={() => target.current} show={show} placement="left">
+            {({
+              placement, arrowProps, show: _show, popper, ...props
+            }) => (
+              <div
+                {...props}
+                className="epp-overlay"
+                onMouseEnter={() => setShow(true)}
+                onMouseLeave={() => setShow(false)}
+              >
+                Number of days left to achieve the next stage of Exam Pass Qualification.{' '}
+                <a
+                  href="https://www.mindhubpro.com/exam-pass-pledge#:~:text=To%20make%20an%20Exam%20Pass,where%20the%20exam%20was%20taken."
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="epp-link"
+                >
+                  More info
+                </a>
+              </div>
+            )}
+          </Overlay>
+        </>
+      );
+    },
+    accessor: 'examReady.eppDaysLeft',
+    Cell: ({ row }) => {
+      const { eppDaysLeft = null } = row.values.examReady;
+      return <span>{eppDaysLeft !== null ? eppDaysLeft : '--'}</span>;
+    },
   },
   {
     Header: '',

--- a/src/features/Students/StudentsFilters/__test__/indext.test.jsx
+++ b/src/features/Students/StudentsFilters/__test__/indext.test.jsx
@@ -1,78 +1,176 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { renderWithProviders } from 'test-utils';
 import { fireEvent, act } from '@testing-library/react';
 
+import { renderWithProviders } from 'test-utils';
 import StudentsFilters from 'features/Students/StudentsFilters';
 
-jest.mock('@edx/frontend-platform/logging', () => ({
-  logError: jest.fn(),
-}));
+import { fetchStudentsData } from 'features/Students/data';
+
+jest.mock('features/Students/data', () => {
+  const actual = jest.requireActual('features/Students/data');
+  return {
+    ...actual,
+    fetchStudentsData: jest.fn(() => ({ type: 'FETCH_STUDENTS' })),
+  };
+});
+
+jest.mock('features/Common/data', () => {
+  const actual = jest.requireActual('features/Common/data');
+  return {
+    ...actual,
+    fetchAllCourses: jest.fn(() => ({ type: 'FETCH_COURSES' })),
+    fetchAllClassesData: jest.fn(() => ({ type: 'FETCH_CLASSES' })),
+  };
+});
 
 describe('StudentsFilters', () => {
-  const resetPagination = jest.fn();
-  const mockSetFilters = jest.fn();
+  const mockState = {
+    main: {
+      username: 'demo_instructor',
+      institution: { id: 456, name: 'Demo Institution' },
+    },
+    common: {
+      allCourses: {
+        status: 'SUCCEEDED',
+        data: [
+          { masterCourseName: 'Python 101' },
+          { masterCourseName: 'Data Science' },
+        ],
+      },
+      allClasses: {
+        status: 'SUCCEEDED',
+        data: [
+          { className: 'Class A' },
+          { className: 'Class B' },
+        ],
+      },
+    },
+    students: {
+      filters: {},
+      table: {
+        data: [],
+        count: 0,
+        num_pages: 0,
+        current_page: 1,
+      },
+    },
+  };
 
   beforeEach(() => {
-    mockSetFilters.mockClear();
+    jest.clearAllMocks();
   });
 
-  test('Should have the buttons disabled if the inputs are empty', () => {
-    const { getByText } = renderWithProviders(
-      <StudentsFilters resetPagination={resetPagination} />,
-    );
+  test('renders all basic fields and buttons disabled initially', () => {
+    const { getByPlaceholderText, getAllByText, getByText } = renderWithProviders(<StudentsFilters />, {
+      preloadedState: mockState,
+    });
 
-    const resetFilterButton = getByText('Reset');
-    const applyFilterButton = getByText('Apply');
-
-    expect(resetFilterButton).toBeDisabled();
-    expect(applyFilterButton).toBeDisabled();
-  });
-
-  test('Should render name input and call service when apply filters', async () => {
-    const { getByText, getByPlaceholderText, getByTestId } = renderWithProviders(
-      <StudentsFilters resetPagination={resetPagination} />,
-    );
+    const studentNameElements = getAllByText('Student name');
+    expect(studentNameElements.length).toBeGreaterThan(0);
 
     expect(getByPlaceholderText('Student name')).toBeInTheDocument();
+
     expect(getByText('Course')).toBeInTheDocument();
     expect(getByText('Class')).toBeInTheDocument();
     expect(getByText('Exam ready')).toBeInTheDocument();
 
-    const inputName = getByTestId('studentInput');
-    const buttonApplyFilters = getByText('Apply');
-
-    fireEvent.change(inputName, {
-      target: { value: 'John Doe' },
-    });
-
-    expect(inputName).toHaveValue('John Doe');
-
-    await act(async () => {
-      fireEvent.click(buttonApplyFilters);
-    });
+    const resetButton = getByText('Reset');
+    const applyButton = getByText('Apply');
+    expect(resetButton).toBeDisabled();
+    expect(applyButton).toBeDisabled();
   });
 
-  test('Clear filters', async () => {
-    const { getByPlaceholderText, getByText } = renderWithProviders(
-      <StudentsFilters
-        resetPagination={resetPagination}
-      />,
-    );
-
-    const nameInput = getByPlaceholderText('Student name');
-    const buttonClearFilters = getByText('Reset');
-
-    expect(nameInput).toBeInTheDocument();
-
-    fireEvent.change(nameInput, { target: { value: 'Name' } });
-
-    expect(nameInput).toHaveValue('Name');
-
-    await act(async () => {
-      fireEvent.click(buttonClearFilters);
+  test('enables Apply button when typing a student name and dispatches correct actions', async () => {
+    const { getByTestId, getByText, store } = renderWithProviders(<StudentsFilters />, {
+      preloadedState: mockState,
     });
 
-    expect(nameInput).toHaveValue('');
+    const input = getByTestId('studentInput');
+    const applyButton = getByText('Apply');
+
+    fireEvent.change(input, { target: { value: 'Alice' } });
+    expect(input).toHaveValue('Alice');
+    expect(applyButton).not.toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(applyButton);
+    });
+
+    const state = store.getState();
+    expect(state.students.filters.learner_name).toBe('Alice');
+    expect(state.students.filters.institution_id).toBe(456);
+    expect(fetchStudentsData).toHaveBeenCalled();
+  });
+
+  test('switches to email input and applies filter correctly', async () => {
+    const {
+      getByTestId, getByPlaceholderText, getByText, store,
+    } = renderWithProviders(
+      <StudentsFilters />,
+      { preloadedState: mockState },
+    );
+
+    const emailCheckbox = getByTestId('emailCheckbox');
+    fireEvent.click(emailCheckbox);
+
+    const emailInput = getByPlaceholderText('Student email');
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+
+    const applyButton = getByText('Apply');
+
+    await act(async () => {
+      fireEvent.click(applyButton);
+    });
+
+    const state = store.getState();
+    expect(state.students.filters.learner_email).toBe('test@example.com');
+    expect(state.students.filters.institution_id).toBe(456);
+    expect(fetchStudentsData).toHaveBeenCalled();
+  });
+
+  test('resets filters when clicking Reset button', async () => {
+    const { getByTestId, getByText, store } = renderWithProviders(<StudentsFilters />, {
+      preloadedState: mockState,
+    });
+
+    const input = getByTestId('studentInput');
+    fireEvent.change(input, { target: { value: 'Bob' } });
+    expect(input).toHaveValue('Bob');
+
+    const resetButton = getByText('Reset');
+    expect(resetButton).not.toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(resetButton);
+    });
+
+    const state = store.getState();
+    expect(state.students.filters).toEqual({});
+    expect(fetchStudentsData).toHaveBeenCalledWith(
+      'demo_instructor',
+      expect.objectContaining({ institution_id: 456 }),
+    );
+  });
+
+  test('renders all Exam Ready options', async () => {
+    const { getByText, getAllByText } = renderWithProviders(<StudentsFilters />, {
+      preloadedState: mockState,
+    });
+
+    const select = getByText('Exam ready');
+    fireEvent.mouseDown(select);
+
+    const expectedOptions = [
+      'In Progress',
+      'Restarted',
+      'EPP Eligible',
+      'Unavailable',
+      'Not Started',
+    ];
+
+    expectedOptions.forEach((option) => {
+      expect(getAllByText(option)[0]).toBeInTheDocument();
+    });
   });
 });

--- a/src/features/Students/StudentsFilters/index.jsx
+++ b/src/features/Students/StudentsFilters/index.jsx
@@ -16,8 +16,11 @@ import { RequestStatus } from 'features/constants';
 import { isInvalidUserOrInstitution } from 'helpers';
 
 const examReadyOptions = [
-  { value: true, label: 'Yes' },
-  { value: false, label: 'No' },
+  { value: 'IN_PROGRESS', label: 'In Progress' },
+  { value: 'RESTARTED', label: 'Restarted' },
+  { value: 'EPP_ELIGIBLE', label: 'EPP Eligible' },
+  { value: 'UNAVAILABLE', label: 'Unavailable' },
+  { value: 'NOT_STARTED', label: 'Not Started' },
 ];
 
 const initialStudentState = {

--- a/src/features/Students/StudentsPage/__test__/index.test.jsx
+++ b/src/features/Students/StudentsPage/__test__/index.test.jsx
@@ -25,7 +25,11 @@ const mockStore = {
           firstAccess: 'Fri, 25 Aug 2023 19:01:23 GMT',
           lastAccess: 'Fri, 25 Aug 2023 20:20:22 GMT',
           status: 'Active',
-          examReady: true,
+          examReady: {
+            status: 'Complete',
+            lastExamDate: '2024-03-15T10:00:00Z',
+            eppDaysLeft: 45,
+          },
         },
         {
           learnerName: 'Student 2',
@@ -39,7 +43,11 @@ const mockStore = {
           firstAccess: 'Sat, 26 Aug 2023 19:01:24 GMT',
           lastAccess: 'Sat, 26 Aug 2023 21:22:22 GMT',
           status: 'Pending',
-          examReady: null,
+          examReady: {
+            status: 'Complete',
+            lastExamDate: '2024-03-15T10:00:00Z',
+            eppDaysLeft: 45,
+          },
         },
       ],
       count: 2,

--- a/src/features/Students/StudentsTable/__test__/columns.test.jsx
+++ b/src/features/Students/StudentsTable/__test__/columns.test.jsx
@@ -29,12 +29,18 @@ describe('getColumns', () => {
             courseName: 'Demo Course 1',
             classId: 'ccx-v1:demo+demo1+2020+ccx@3',
             className: 'test ccx1',
+            institutionName: 'Test Institution',
             created: '2024-02-13T18:31:27.399407Z',
             status: 'Active',
-            examReady: false,
+            examReady: {
+              status: 'Complete',
+              lastExamDate: '2024-03-15T10:00:00Z',
+              eppDaysLeft: 45,
+            },
             startDate: '2024-02-13T17:42:22Z',
-            endDate: null,
-            completePercentage: 0.0,
+            endDate: '2024-12-31T23:59:59Z',
+            completePercentage: 75.5,
+            userId: 'user123',
           },
         ],
       },
@@ -43,7 +49,7 @@ describe('getColumns', () => {
 
   test('returns an array of columns with correct properties', () => {
     expect(getColumns()).toBeInstanceOf(Array);
-    expect(getColumns()).toHaveLength(9);
+    expect(getColumns()).toHaveLength(11);
 
     const [
       nameColumn,
@@ -54,6 +60,9 @@ describe('getColumns', () => {
       dateColumn,
       progressColumn,
       examReadyColumn,
+      lastExamDateColumn,
+      eppDaysLeftColumn,
+      actionsColumn,
     ] = getColumns();
 
     expect(nameColumn).toHaveProperty('Header', 'Student');
@@ -79,17 +88,292 @@ describe('getColumns', () => {
 
     expect(examReadyColumn).toHaveProperty('Header', 'Exam Ready');
     expect(examReadyColumn).toHaveProperty('accessor', 'examReady');
+
+    expect(lastExamDateColumn).toHaveProperty('Header', 'Last exam date');
+    expect(lastExamDateColumn).toHaveProperty('accessor', 'examReady.lastExamDate');
+
+    expect(eppDaysLeftColumn).toHaveProperty('accessor', 'examReady.eppDaysLeft');
+
+    expect(actionsColumn).toHaveProperty('Header', '');
+    expect(actionsColumn).toHaveProperty('accessor', 'classId');
+    expect(actionsColumn).toHaveProperty('disableSortBy', true);
   });
 
-  test('Show menu dropdown', async () => {
-    const ActionColumn = () => getColumns()[8].Cell({
+  test('renders Student column with correct link', () => {
+    const StudentCell = () => getColumns()[0].Cell({
+      row: {
+        values: { learnerName: 'Test User' },
+        original: { learnerEmail: 'testuser@example.com' },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter initialEntries={['/students/?institutionId=1']}>
+        <Route path="/students/">
+          <StudentCell />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    const link = component.getByText('Test User');
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute('href')).toContain('/students/testuser%40example.com');
+    expect(link.getAttribute('href')).toContain('previous=students');
+  });
+
+  test('renders Email column with mailto link', () => {
+    const EmailCell = () => getColumns()[1].Cell({
+      row: {
+        values: { learnerEmail: 'testuser@example.com' },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter>
+        <EmailCell />
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    const link = component.getByText('testuser@example.com');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'mailto:testuser@example.com');
+  });
+
+  test('renders Status column with correct badge', () => {
+    const StatusCell = () => getColumns()[3].Cell({
+      row: {
+        values: { status: 'Active' },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter>
+        <StatusCell />
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    const badge = component.getByText('Active');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass('text-capitalize');
+  });
+
+  test('renders Class Name column with correct link', () => {
+    const ClassNameCell = () => getColumns()[4].Cell({
+      row: {
+        values: { className: 'test ccx1' },
+        original: { classId: 'ccx-v1:demo+demo1+2020+ccx@3' },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter initialEntries={['/students/?institutionId=1']}>
+        <Route path="/students/">
+          <ClassNameCell />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    const link = component.getByText('test ccx1');
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute('href')).toContain('/classes/ccx-v1:demo+demo1+2020+ccx@3');
+    expect(link.getAttribute('href')).toContain('previous=students');
+  });
+
+  test('renders Start - End Date column with formatted dates', () => {
+    const DateCell = () => getColumns()[5].Cell({
+      row: {
+        original: {
+          startDate: '2024-02-13T17:42:22Z',
+          endDate: '2024-12-31T23:59:59Z',
+        },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter>
+        <DateCell />
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    expect(component.container.textContent).toContain('02/13/24 - 12/31/24');
+  });
+
+  test('renders Start - End Date column with empty dates', () => {
+    const DateCell = () => getColumns()[5].Cell({
+      row: {
+        original: {
+          startDate: null,
+          endDate: null,
+        },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter>
+        <DateCell />
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    expect(component.container.textContent).toBe(' - ');
+  });
+
+  test('renders Progress column with percentage text', () => {
+    const ProgressCell = () => getColumns()[6].Cell({
+      row: {
+        values: { completePercentage: 75.5 },
+      },
+    });
+
+    const { getByText } = renderWithProviders(
+      <MemoryRouter>
+        <ProgressCell />
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    expect(getByText('75%')).toBeInTheDocument();
+  });
+
+  test('renders Exam Ready column with ProgressSteps', () => {
+    const ExamReadyCell = () => getColumns()[7].Cell({
       row: {
         values: {
-          classId: 'CCX1',
+          examReady: {
+            status: 'Complete',
+          },
+        },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter>
+        <ExamReadyCell />
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    expect(component.container.firstChild).toBeInTheDocument();
+  });
+
+  test('renders Last exam date with formatted date', () => {
+    const LastExamDateCell = () => getColumns()[8].Cell({
+      row: {
+        values: {
+          examReady: {
+            lastExamDate: '2024-03-15T10:00:00Z',
+          },
+        },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter>
+        <LastExamDateCell />
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    expect(component.getByText('03/15/24')).toBeInTheDocument();
+  });
+
+  test('renders Last exam date with placeholder when null', () => {
+    const LastExamDateCell = () => getColumns()[8].Cell({
+      row: {
+        values: {
+          examReady: {
+            lastExamDate: null,
+          },
+        },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter>
+        <LastExamDateCell />
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    expect(component.getByText('--')).toBeInTheDocument();
+  });
+
+  test('renders EPP days left header with tooltip', () => {
+    const HeaderComponent = () => {
+      const columns = getColumns();
+      const { Header } = columns[9];
+      return <Header />;
+    };
+
+    const component = renderWithProviders(
+      <MemoryRouter>
+        <HeaderComponent />
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    expect(component.getByText('Epp days left')).toBeInTheDocument();
+    expect(component.container.querySelector('.fa-circle-info')).toBeInTheDocument();
+  });
+
+  test('renders EPP days left value', () => {
+    const EppDaysLeftCell = () => getColumns()[9].Cell({
+      row: {
+        values: {
+          examReady: {
+            eppDaysLeft: 45,
+          },
+        },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter>
+        <EppDaysLeftCell />
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    expect(component.getByText('45')).toBeInTheDocument();
+  });
+
+  test('renders EPP days left with placeholder when null', () => {
+    const EppDaysLeftCell = () => getColumns()[9].Cell({
+      row: {
+        values: {
+          examReady: {
+            eppDaysLeft: null,
+          },
+        },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter>
+        <EppDaysLeftCell />
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    expect(component.getByText('--')).toBeInTheDocument();
+  });
+
+  test('shows menu dropdown with View progress link', () => {
+    const ActionColumn = () => getColumns()[10].Cell({
+      row: {
+        values: {
+          classId: 'ccx-v1:demo+demo1+2020+ccx@3',
         },
         original: {
-          classId: 'CCX1',
-          userId: '1',
+          classId: 'ccx-v1:demo+demo1+2020+ccx@3',
+          userId: 'user123',
+          status: 'Active',
+          learnerEmail: 'testuser@example.com',
         },
       },
     });
@@ -105,6 +389,99 @@ describe('getColumns', () => {
 
     const button = component.getByTestId('droprown-action');
     fireEvent.click(button);
+
+    const viewProgressLink = component.getByText('View progress');
+    expect(viewProgressLink).toBeInTheDocument();
+    expect(viewProgressLink).toHaveAttribute('target', '_blank');
+  });
+
+  test('shows DeleteEnrollment option when hasEnrollmentPrivilege is true and status is not expired', () => {
+    const ActionColumn = () => getColumns({ hasEnrollmentPrivilege: true })[10].Cell({
+      row: {
+        values: {
+          classId: 'ccx-v1:demo+demo1+2020+ccx@3',
+        },
+        original: {
+          classId: 'ccx-v1:demo+demo1+2020+ccx@3',
+          userId: 'user123',
+          status: 'Active',
+          learnerEmail: 'testuser@example.com',
+        },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter initialEntries={['/students/']}>
+        <Route path="/students/">
+          <ActionColumn />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    const button = component.getByTestId('droprown-action');
+    fireEvent.click(button);
+
+    expect(component.getByText('View progress')).toBeInTheDocument();
+  });
+
+  test('does not show DeleteEnrollment option when status is expired', () => {
+    const ActionColumn = () => getColumns({ hasEnrollmentPrivilege: true })[10].Cell({
+      row: {
+        values: {
+          classId: 'ccx-v1:demo+demo1+2020+ccx@3',
+        },
+        original: {
+          classId: 'ccx-v1:demo+demo1+2020+ccx@3',
+          userId: 'user123',
+          status: 'Expired',
+          learnerEmail: 'testuser@example.com',
+        },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter initialEntries={['/students/']}>
+        <Route path="/students/">
+          <ActionColumn />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    const button = component.getByTestId('droprown-action');
+    fireEvent.click(button);
+
+    expect(component.getByText('View progress')).toBeInTheDocument();
+  });
+
+  test('does not show DeleteEnrollment option when hasEnrollmentPrivilege is false', () => {
+    const ActionColumn = () => getColumns({ hasEnrollmentPrivilege: false })[10].Cell({
+      row: {
+        values: {
+          classId: 'ccx-v1:demo+demo1+2020+ccx@3',
+        },
+        original: {
+          classId: 'ccx-v1:demo+demo1+2020+ccx@3',
+          userId: 'user123',
+          status: 'Active',
+          learnerEmail: 'testuser@example.com',
+        },
+      },
+    });
+
+    const component = renderWithProviders(
+      <MemoryRouter initialEntries={['/students/']}>
+        <Route path="/students/">
+          <ActionColumn />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    const button = component.getByTestId('droprown-action');
+    fireEvent.click(button);
+
     expect(component.getByText('View progress')).toBeInTheDocument();
   });
 });

--- a/src/features/Students/StudentsTable/__test__/index.test.jsx
+++ b/src/features/Students/StudentsTable/__test__/index.test.jsx
@@ -8,17 +8,26 @@ import { renderWithProviders } from 'test-utils';
 describe('Student Table', () => {
   test('renders StudentsTable without data', () => {
     const mockStore = {
+      main: {
+        selectedInstitution: {
+          id: 1,
+        },
+      },
       students: {
         table: {
           data: [],
-          count: 2,
+          count: 0,
           num_pages: 1,
           current_page: 1,
         },
       },
     };
     renderWithProviders(
-      <StudentsTable />,
+      <MemoryRouter initialEntries={['/students']}>
+        <Route path="/students">
+          <StudentsTable />
+        </Route>
+      </MemoryRouter>,
       { preloadedState: mockStore },
     );
     const emptyTableText = screen.getByText('No students found.');
@@ -27,36 +36,59 @@ describe('Student Table', () => {
 
   test('renders StudentsTable with data', () => {
     const mockStore = {
+      main: {
+        selectedInstitution: {
+          id: 1,
+        },
+      },
       students: {
         table: {
           data: [
             {
               learnerName: 'Student 1',
               learnerEmail: 'student1@example.com',
-              courseId: '1',
+              institutionName: 'Institution 1',
+              courseId: 'course-v1:demo+demo1+2020',
               courseName: 'course 1',
-              classId: '1',
+              classId: 'ccx-v1:demo+demo1+2020+ccx@1',
               className: 'class 1',
               instructors: ['Instructor 1'],
               created: 'Fri, 25 Aug 2023 19:01:22 GMT',
+              startDate: '2023-08-25T19:01:22Z',
+              endDate: '2024-08-25T19:01:22Z',
               firstAccess: 'Fri, 25 Aug 2023 19:01:23 GMT',
               lastAccess: 'Fri, 25 Aug 2023 20:20:22 GMT',
               status: 'Active',
-              examReady: true,
+              completePercentage: 75.5,
+              examReady: {
+                status: 'Complete',
+                lastExamDate: '2024-03-15T10:00:00Z',
+                eppDaysLeft: 45,
+              },
+              userId: 'user1',
             },
             {
               learnerName: 'Student 2',
               learnerEmail: 'student2@example.com',
-              courseId: '2',
+              institutionName: 'Institution 2',
+              courseId: 'course-v1:demo+demo2+2020',
               courseName: 'course 2',
-              classId: '2',
+              classId: 'ccx-v1:demo+demo2+2020+ccx@2',
               className: 'class 2',
               instructors: ['Instructor 2'],
               created: 'Sat, 26 Aug 2023 19:01:22 GMT',
+              startDate: '2023-08-26T19:01:22Z',
+              endDate: '2024-08-26T19:01:22Z',
               firstAccess: 'Sat, 26 Aug 2023 19:01:24 GMT',
               lastAccess: 'Sat, 26 Aug 2023 21:22:22 GMT',
               status: 'Pending',
-              examReady: null,
+              completePercentage: 45.0,
+              examReady: {
+                status: 'Incomplete',
+                lastExamDate: null,
+                eppDaysLeft: null,
+              },
+              userId: 'user2',
             },
           ],
           count: 2,
@@ -81,12 +113,128 @@ describe('Student Table', () => {
     expect(component.container).toHaveTextContent('student1@example.com');
     expect(component.container).toHaveTextContent('student2@example.com');
 
+    expect(component.container).toHaveTextContent('Institution 1');
+    expect(component.container).toHaveTextContent('Institution 2');
+
     expect(component.container).toHaveTextContent('class 1');
     expect(component.container).toHaveTextContent('class 2');
 
-    expect(component.container).toHaveTextContent('Yes');
-    expect(component.container).toHaveTextContent('No');
+    expect(component.container).toHaveTextContent('Pending');
+
+    expect(component.container).toHaveTextContent('08/25/23');
+    expect(component.container).toHaveTextContent('08/26/23');
+
+    expect(component.container).toHaveTextContent('03/15/24');
+
+    expect(component.container).toHaveTextContent('45');
 
     expect(screen.queryByText('No students found.')).toBeNull();
+  });
+
+  test('renders StudentsTable with complete table structure', () => {
+    const mockStore = {
+      main: {
+        selectedInstitution: {
+          id: 1,
+        },
+      },
+      students: {
+        table: {
+          data: [
+            {
+              learnerName: 'Test Student',
+              learnerEmail: 'test@example.com',
+              institutionName: 'Test Institution',
+              courseId: 'course-v1:test+test+2024',
+              courseName: 'Test Course',
+              classId: 'ccx-v1:test+test+2024+ccx@1',
+              className: 'Test Class',
+              status: 'Active',
+              startDate: '2024-01-01T00:00:00Z',
+              endDate: '2024-12-31T23:59:59Z',
+              completePercentage: 50.0,
+              examReady: {
+                status: 'Complete',
+                lastExamDate: '2024-03-15T10:00:00Z',
+                eppDaysLeft: 30,
+              },
+              userId: 'testuser',
+            },
+          ],
+          count: 1,
+          num_pages: 1,
+          current_page: 1,
+        },
+      },
+    };
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/students']}>
+        <Route path="/students">
+          <StudentsTable />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    expect(screen.getByText('Student')).toBeInTheDocument();
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText('Institution')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Class Name')).toBeInTheDocument();
+    expect(screen.getByText('Start - End Date')).toBeInTheDocument();
+    expect(screen.getByText('Current Grade')).toBeInTheDocument();
+    expect(screen.getByText('Exam Ready')).toBeInTheDocument();
+    expect(screen.getByText('Last exam date')).toBeInTheDocument();
+    expect(screen.getByText('Epp days left')).toBeInTheDocument();
+  });
+
+  test('renders StudentsTable with placeholder values when data is null', () => {
+    const mockStore = {
+      main: {
+        selectedInstitution: {
+          id: 1,
+        },
+      },
+      students: {
+        table: {
+          data: [
+            {
+              learnerName: 'Student Without Dates',
+              learnerEmail: 'nodates@example.com',
+              institutionName: 'Test Institution',
+              courseId: 'course-v1:test+test+2024',
+              courseName: 'Test Course',
+              classId: 'ccx-v1:test+test+2024+ccx@1',
+              className: 'Test Class',
+              status: 'Active',
+              startDate: null,
+              endDate: null,
+              completePercentage: 0,
+              examReady: {
+                status: 'Incomplete',
+                lastExamDate: null,
+                eppDaysLeft: null,
+              },
+              userId: 'testuser',
+            },
+          ],
+          count: 1,
+          num_pages: 1,
+          current_page: 1,
+        },
+      },
+    };
+
+    const component = renderWithProviders(
+      <MemoryRouter initialEntries={['/students']}>
+        <Route path="/students">
+          <StudentsTable />
+        </Route>
+      </MemoryRouter>,
+      { preloadedState: mockStore },
+    );
+
+    expect(component.container).toHaveTextContent('--');
   });
 });

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -3,12 +3,16 @@ import {
   Dropdown,
   IconButton,
   Icon,
+  Overlay,
 } from '@edx/paragon';
 import { Link } from 'react-router-dom';
 import { MoreHoriz } from '@edx/paragon/icons';
 import { getConfig } from '@edx/frontend-platform';
+import React from 'react';
 
-import { formatUTCDate, Badge, STUDENT_STATUS_VARIANTS } from 'react-paragon-topaz';
+import {
+  formatUTCDate, Badge, STUDENT_STATUS_VARIANTS, ProgressSteps,
+} from 'react-paragon-topaz';
 import { useInstitutionIdQueryParam } from 'hooks';
 
 import DeleteEnrollment from 'features/Main/DeleteEnrollment';
@@ -104,7 +108,65 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
   {
     Header: 'Exam Ready',
     accessor: 'examReady',
-    Cell: ({ row }) => (row.values.examReady ? 'Yes' : 'No'),
+    Cell: ({ row }) => (<ProgressSteps status={row.values.examReady.status.toLowerCase()} />),
+  },
+  {
+    Header: 'Last exam date',
+    accessor: 'examReady.lastExamDate',
+    Cell: ({ row }) => {
+      const lastExamDate = row.values.examReady.lastExamDate
+        ? formatUTCDate(row.values.examReady.lastExamDate, 'MM/dd/yy')
+        : '--';
+      return <span>{lastExamDate}</span>;
+    },
+  },
+  {
+    Header: () => {
+      const [show, setShow] = React.useState(false);
+      const target = React.useRef(null);
+
+      return (
+        <>
+          <span
+            ref={target}
+            className="epp-header"
+            onMouseEnter={() => setShow(true)}
+            onMouseLeave={() => setShow(false)}
+          >
+            Epp days left
+            <i className="fa-regular fa-circle-info ml-1" />
+          </span>
+
+          <Overlay target={() => target.current} show={show} placement="left">
+            {({
+              placement, arrowProps, show: _show, popper, ...props
+            }) => (
+              <div
+                {...props}
+                className="epp-overlay"
+                onMouseEnter={() => setShow(true)}
+                onMouseLeave={() => setShow(false)}
+              >
+                Number of days left to achieve the next stage of Exam Pass Qualification.{' '}
+                <a
+                  href="https://www.mindhubpro.com/exam-pass-pledge#:~:text=To%20make%20an%20Exam%20Pass,where%20the%20exam%20was%20taken."
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="epp-link"
+                >
+                  More info
+                </a>
+              </div>
+            )}
+          </Overlay>
+        </>
+      );
+    },
+    accessor: 'examReady.eppDaysLeft',
+    Cell: ({ row }) => {
+      const { eppDaysLeft = null } = row.values.examReady;
+      return <span>{eppDaysLeft !== null ? eppDaysLeft : '--'}</span>;
+    },
   },
   {
     Header: '',

--- a/src/index.scss
+++ b/src/index.scss
@@ -20,3 +20,24 @@ body {
 .course-progress {
   color: $gray-70;
 }
+
+.epp-header {
+  cursor: pointer;
+}
+
+.epp-overlay {
+  background-color: $overlay-bg;
+  color: $white;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 14px;
+  max-width: 320px;
+  box-shadow: 0 4px 12px $overlay-shadow;
+  z-index: 9999;
+  line-height: 1.4;
+}
+
+a.epp-link {
+  color: $blue-50;
+  text-decoration: underline;
+}


### PR DESCRIPTION
### Description
This update adds three new columns to the students table:

- **Exam Ready** — displays the current readiness status for each exam.  
- **Last Practice Exam** — shows the most recent practice exam taken by the student.  
- **EPP Days Left** — indicates the number of days remaining to achieve the next stage of Exam Pass Qualification.  

Additionally, the “EPP Days Left” column now includes a **custom overlay tooltip** that allows users to hover and open an external “More info” link without interaction issues.  

- Fixed filters for the new exam ready implementation

---

### Ticket
https://pearson.atlassian.net/browse/PADV-2792

---

### Screenshots
<img width="1625" height="1034" alt="Screenshot 2025-11-10 at 2 33 08 PM" src="https://github.com/user-attachments/assets/ff4c5b6f-3326-4451-a8e8-fd832587643d" />


---

### How to Test
1. Navigate to the **Students** or **class details** page.  
2. Verify that the following columns appear:
   - `Exam Ready`
   - `Last Practice Exam`
   - `EPP Days Left`
3. Hover over **EPP Days Left** to display the dark overlay with description text and a “More info” link.  
4. Click the link to ensure it opens in a new tab correctly.  
5. Move the cursor away and confirm the overlay closes automatically.  

---

