### PR TITLE
fix: percentage format

### DIFF
--- a/src/features/Classes/ClassDetailPage/columns.jsx
+++ b/src/features/Classes/ClassDetailPage/columns.jsx
@@ -60,11 +60,21 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
   {
     Header: 'Current Grade',
     accessor: 'completePercentage',
-    Cell: ({ row }) => (
-      <span className="course-progress">
-        {row.values.completePercentage}%
-      </span>
-    ),
+    Cell: ({ row }) => {
+      const raw = row?.values?.completePercentage;
+
+      const safeNumber = Number(raw);
+
+      const value = Number.isFinite(safeNumber)
+        ? Math.min(100, Math.max(0, Math.floor(safeNumber)))
+        : 0;
+
+      return (
+        <span className="course-progress">
+          {value}%
+        </span>
+      );
+    },
   },
   {
     Header: 'Exam ready',

--- a/src/features/Students/StudentsDetails/columns.jsx
+++ b/src/features/Students/StudentsDetails/columns.jsx
@@ -49,11 +49,18 @@ const columns = [
     accessor: 'completePercentage',
     Cell: ({ row }) => {
       const addQueryParam = useInstitutionIdQueryParam();
+      const raw = row?.values?.completePercentage;
+
+      const safeNumber = Number(raw);
+
+      const percentage = Number.isFinite(safeNumber)
+        ? Math.min(100, Math.max(0, Math.floor(safeNumber)))
+        : 0;
 
       return (
         <div className="d-flex w-100 align-items-center justify-content-center">
           <span className="course-progress mr-3 w-50">
-            {row.values.completePercentage}%
+            {percentage}%
           </span>
           <Link to={addQueryParam(`/classes/${row.original.classId}?previous=students`)}>
             Class details

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -85,11 +85,21 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
   {
     Header: 'Current Grade',
     accessor: 'completePercentage',
-    Cell: ({ row }) => (
-      <span className="course-progress mr-3 w-50">
-        {row.values.completePercentage}%
-      </span>
-    ),
+    Cell: ({ row }) => {
+      const raw = row?.values?.completePercentage;
+
+      const safeNumber = Number(raw);
+
+      const value = Number.isFinite(safeNumber)
+        ? Math.min(100, Math.max(0, Math.floor(safeNumber)))
+        : 0;
+
+      return (
+        <span className="course-progress mr-3 w-50">
+          {value}%
+        </span>
+      );
+    },
   },
   {
     Header: 'Exam Ready',


### PR DESCRIPTION
# Description

In this PR is fixed the format for percentages in the column `Current Grade`, previously the percentage was not formatted, causing some percentages displays decimals.

## Before
<img width="444" height="110" alt="Screenshot 2025-11-19 at 12 44 30 PM" src="https://github.com/user-attachments/assets/a71bd1cb-78af-409d-b285-56b8045bc2b9" />



## After
<img width="236" height="114" alt="Screenshot 2025-11-19 at 12 44 39 PM" src="https://github.com/user-attachments/assets/bde59009-1796-4819-b631-2d4d7e4c3f5e" />

