### PR TITLE
PADV-3193 - Add start date search/filter to Classes page

### DIFF
--- a/src/features/Classes/ClassesFilters/__test__/index.test.jsx
+++ b/src/features/Classes/ClassesFilters/__test__/index.test.jsx
@@ -90,6 +90,42 @@ describe('Classes filters', () => {
     expect(button).toBeEnabled();
   });
 
+  test('Should enable Apply when start_date is set', () => {
+    const { getByText, getByTestId } = renderWithProviders(
+      <ClassesFilters />,
+      { preloadedState: mockStore },
+    );
+
+    const startDateInput = getByTestId('start_date');
+    const button = getByText('Apply');
+
+    expect(button).toBeDisabled();
+
+    fireEvent.change(startDateInput, {
+      target: { value: '2024-01-15' },
+    });
+
+    expect(button).toBeEnabled();
+  });
+
+  test('Should enable Apply when end_date is set', () => {
+    const { getByText, getByTestId } = renderWithProviders(
+      <ClassesFilters />,
+      { preloadedState: mockStore },
+    );
+
+    const endDateInput = getByTestId('end_date');
+    const button = getByText('Apply');
+
+    expect(button).toBeDisabled();
+
+    fireEvent.change(endDateInput, {
+      target: { value: '2024-02-15' },
+    });
+
+    expect(button).toBeEnabled();
+  });
+
   test('Should call the service when apply filters', async () => {
     const { getByText, getAllByTestId, getByTestId } = renderWithProviders(
       <ClassesFilters />,
@@ -99,6 +135,8 @@ describe('Classes filters', () => {
     const courseSelect = getAllByTestId('select')[0];
     const classSelect = getAllByTestId('select')[1];
     const classInput = getByTestId('class_name');
+    const startDateInput = getByTestId('start_date');
+    const endDateInput = getByTestId('end_date');
     const buttonApply = getByText('Apply');
 
     fireEvent.change(classSelect, {
@@ -111,6 +149,14 @@ describe('Classes filters', () => {
 
     fireEvent.change(classInput, {
       target: { value: 'math' },
+    });
+
+    fireEvent.change(startDateInput, {
+      target: { value: '2024-01-15' },
+    });
+
+    fireEvent.change(endDateInput, {
+      target: { value: '2024-02-15' },
     });
 
     await act(async () => {
@@ -128,6 +174,8 @@ describe('Classes filters', () => {
 
     const courseSelect = getAllByTestId('select')[0];
     const classInput = getByTestId('class_name');
+    const startDateInput = getByTestId('start_date');
+    const endDateInput = getByTestId('end_date');
     const buttonReset = getByText('Reset');
 
     fireEvent.change(courseSelect, {
@@ -138,10 +186,40 @@ describe('Classes filters', () => {
       target: { value: 'test' },
     });
 
+    fireEvent.change(startDateInput, {
+      target: { value: '2024-01-15' },
+    });
+
+    fireEvent.change(endDateInput, {
+      target: { value: '2024-02-15' },
+    });
+
     await act(async () => {
       fireEvent.click(buttonReset);
     });
 
     expect(classInput).toHaveValue('');
+    expect(startDateInput).toHaveValue('');
+    expect(endDateInput).toHaveValue('');
+  });
+
+  test('Should subtract four weeks from start_date before sending to backend', async () => {
+    const { getByText, getByTestId } = renderWithProviders(
+      <ClassesFilters />,
+      { preloadedState: mockStore },
+    );
+
+    const startDateInput = getByTestId('start_date');
+    const buttonApply = getByText('Apply');
+
+    fireEvent.change(startDateInput, {
+      target: { value: '2024-02-12' },
+    });
+
+    await act(async () => {
+      fireEvent.click(buttonApply);
+    });
+
+    expect(startDateInput).toHaveValue('2024-02-12');
   });
 });

--- a/src/features/Classes/ClassesFilters/index.jsx
+++ b/src/features/Classes/ClassesFilters/index.jsx
@@ -36,9 +36,21 @@ const ClassesFilters = () => {
     || null,
   );
   const [classFilter, setClassFilter] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
 
   const isValidClassFilter = classFilter.trim().length > 1;
-  const isButtonDisabled = courseSelected === null && classSelected === null && !isValidClassFilter;
+  const isButtonDisabled = courseSelected === null
+  && classSelected === null
+  && !isValidClassFilter
+  && !startDate
+  && !endDate;
+
+  const subtractFourWeeks = (dateStr) => {
+    const date = new Date(dateStr);
+    date.setDate(date.getDate() - 28);
+    return date.toISOString().split('T')[0];
+  };
 
   const initialRequestParams = {
     limit: true,
@@ -56,6 +68,8 @@ const ClassesFilters = () => {
       course_name: courseSelected?.value,
       institution_id: institution?.id,
       class_name: classFilter || '',
+      start_date: startDate ? subtractFourWeeks(startDate) : null,
+      end_date: endDate || null,
     };
 
     dispatch(updateFilters(filtersParams));
@@ -68,6 +82,8 @@ const ClassesFilters = () => {
     setClassSelected(null);
     setCourseSelected(null);
     setClassFilter('');
+    setStartDate('');
+    setEndDate('');
     dispatch(updateFilters({}));
   };
 
@@ -90,6 +106,30 @@ const ClassesFilters = () => {
             data-testid="class_name"
             onChange={(e) => setClassFilter(e.target.value)}
             value={classFilter}
+          />
+        </Form.Group>
+      </Form.Row>
+      <Form.Row className="d-flex flex-wrap w-100 mr-0">
+        <Form.Group as={Col} className="w-50 px-0">
+          <Form.Control
+            type="date"
+            floatingLabel="Search start date"
+            className="my-1 mr-2"
+            name="start_date"
+            data-testid="start_date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+          />
+        </Form.Group>
+        <Form.Group as={Col} className="w-50 px-0">
+          <Form.Control
+            type="date"
+            floatingLabel="Search end date"
+            className="my-1 mr-0"
+            name="end_date"
+            data-testid="end_date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
           />
         </Form.Group>
       </Form.Row>


### PR DESCRIPTION
# Description
In this PR is added date filters for classes.

## Ticket
https://pearson.atlassian.net/browse/PADV-3193

## Screenshots
<img width="1528" height="734" alt="Screenshot 2026-04-27 at 5 10 20 PM" src="https://github.com/user-attachments/assets/8c568d3f-1a17-458a-8288-d13481f57e22" />


After
<img width="1324" height="604" alt="Screenshot 2026-04-27 at 5 10 08 PM" src="https://github.com/user-attachments/assets/222bc68a-06e4-4c87-9b7b-6f6e7c7aff93" />

## How to test
- Go to /classes