### PR TITLE
PADV-3410 - Modify Support link in Instructor Portal

### DIFF
--- a/src/features/Main/Sidebar/__test__/index.test.jsx
+++ b/src/features/Main/Sidebar/__test__/index.test.jsx
@@ -23,23 +23,31 @@ jest.mock('react-paragon-topaz', () => ({
   getUserRoles: jest.fn(() => (['INSTRUCTOR'])),
 }));
 
+const defaultInitialState = {
+  main: {
+    activeTab: 'dashboard',
+    institution: {},
+  },
+};
+
 describe('Sidebar', () => {
   test('Should render the sidebar with all options', () => {
-    const { getByText } = renderWithProviders(<Sidebar />);
+    const { getByText } = renderWithProviders(
+      <Sidebar />,
+      { preloadedState: defaultInitialState },
+    );
 
-    const homeButton = getByText('Home');
-    const studentsButton = getByText('Students');
-    const classesButton = getByText('Classes');
-    const myProfileButton = getByText('My profile');
-
-    expect(homeButton).toBeInTheDocument();
-    expect(studentsButton).toBeInTheDocument();
-    expect(classesButton).toBeInTheDocument();
-    expect(myProfileButton).toBeInTheDocument();
+    expect(getByText('Home')).toBeInTheDocument();
+    expect(getByText('Students')).toBeInTheDocument();
+    expect(getByText('Classes')).toBeInTheDocument();
+    expect(getByText('My profile')).toBeInTheDocument();
   });
 
   test('Should change selection on click in any item', () => {
-    const { getByRole } = renderWithProviders(<Sidebar />);
+    const { getByRole } = renderWithProviders(
+      <Sidebar />,
+      { preloadedState: defaultInitialState },
+    );
 
     const profileButton = getByRole('button', { name: /my profile/i });
     expect(profileButton).toBeInTheDocument();
@@ -53,10 +61,41 @@ describe('Sidebar', () => {
   test('should render Institution Portal item if has role', () => {
     paragonTopaz.getUserRoles.mockReturnValue(['INSTRUCTOR', 'INSTITUTION_ADMIN']);
 
-    const { getByText } = renderWithProviders(<Sidebar />);
+    const { getByText } = renderWithProviders(
+      <Sidebar />,
+      { preloadedState: defaultInitialState },
+    );
 
-    const portalLink = getByText('Skilling Administrator');
+    expect(getByText('Skilling Administrator')).toBeInTheDocument();
+  });
 
-    expect(portalLink).toBeInTheDocument();
+  test('should use institution supportLink for Contact Support when provided', () => {
+    const customSupportLink = 'https://custom-support.example.com';
+    const { getByText } = renderWithProviders(
+      <Sidebar />,
+      {
+        preloadedState: {
+          ...defaultInitialState,
+          main: {
+            ...defaultInitialState.main,
+            institution: { supportLink: customSupportLink },
+          },
+        },
+      },
+    );
+
+    const contactSupportLink = getByText('Contact Support').closest('a');
+    expect(contactSupportLink).toHaveAttribute('href', customSupportLink);
+  });
+
+  test('should use default Contact Support link when institution has no supportLink', () => {
+    const defaultSupportLink = 'https://skilling.pearsonvue.com/pearson-core/support/';
+    const { getByText } = renderWithProviders(
+      <Sidebar />,
+      { preloadedState: defaultInitialState },
+    );
+
+    const contactSupportLink = getByText('Contact Support').closest('a');
+    expect(contactSupportLink).toHaveAttribute('href', defaultSupportLink);
   });
 });

--- a/src/features/Main/Sidebar/index.jsx
+++ b/src/features/Main/Sidebar/index.jsx
@@ -46,6 +46,7 @@ export const Sidebar = () => {
   const menuItems = [...baseItems];
   const institutionPortalPath = getConfig().INSTITUTION_PORTAL_PATH || '';
   const adminRoles = [USER_ROLES.GLOBAL_STAFF, USER_ROLES.INSTITUTION_ADMIN];
+  const institution = useSelector((state) => state.main.institution);
 
   if (adminRoles.some(role => roles.includes(role)) && institutionPortalPath.length > 0) {
     menuItems.push({
@@ -106,15 +107,21 @@ export const Sidebar = () => {
             link,
             label,
             ...rest
-          }) => (
-            <MenuItem
-              key={link}
-              title={label}
-              as="a"
-              href={link}
-              {...rest}
-            />
-          ))
+          }) => {
+            const resolvedLink = label === 'Contact Support' && institution?.supportLink
+              ? institution.supportLink
+              : link;
+
+            return (
+              <MenuItem
+                key={label}
+                title={label}
+                as="a"
+                href={resolvedLink}
+                {...rest}
+              />
+            );
+          })
         }
       </MenuSection>
     </SidebarBase>


### PR DESCRIPTION
# Description

This PR updates the support link behavior by reading the `support_link` value configured in the institution. If the institution does not provide a support link, the application falls back to the default support link value.

The support link is configured through the Django Admin and consumed by the MFE.

## Ticket
https://pearson.atlassian.net/browse/PADV-3410

## Changes

* Added support link retrieval from the institution configuration.
* Added fallback logic to use the default support link when no institution support link is provided.
* Connected the MFE to consume the institution support link value.
* Support link remains read-only from the MFE and configurable only through Django Admin.

## How to test

* Open Django Admin.
* Navigate to `Home › course_operations › Institutions`.
* Select the desired institution.
* Configure the `Support link` field and save the changes.
* Start the MFE application.
* Verify that the configured institution support link is displayed correctly in the MFE.
* Remove or leave the `Support link` field empty in Django Admin.
* Verify that the application uses the default support link value when no institution support link is configured.
