### PR TITLE
PADV-36372 feat: responsive table

### DIFF
--- a/src/features/Classes/ClassDetailPage/columns.jsx
+++ b/src/features/Classes/ClassDetailPage/columns.jsx
@@ -35,7 +35,7 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
       return (
         <Link
           to={url}
-          className="text-truncate link"
+          className="link"
         >
           {row.values.learnerName}
         </Link>
@@ -170,7 +170,7 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
             data-testid="droprown-action"
             alt="menu for actions"
           />
-          <Dropdown.Menu>
+          <Dropdown.Menu popperConfig={{ strategy: 'fixed' }}>
             <Dropdown.Item
               target="_blank"
               rel="noreferrer"

--- a/src/features/Classes/ClassesPage/columns.jsx
+++ b/src/features/Classes/ClassesPage/columns.jsx
@@ -23,7 +23,7 @@ const columns = [
       return (
         <Link
           to={url}
-          className="text-truncate link"
+          className="link"
         >
           {row.values.className}
         </Link>

--- a/src/features/Main/ActionsDropdown/index.jsx
+++ b/src/features/Main/ActionsDropdown/index.jsx
@@ -29,7 +29,7 @@ const ActionsDropdown = ({ options, vertIcon }) => (
       variant="primary"
       alt="menu for actions"
     />
-    <Dropdown.Menu>
+    <Dropdown.Menu popperConfig={{ strategy: 'fixed' }}>
       {options.map((option) => {
         if (option.visible) {
           return <Option key={option.label} {...option} />;

--- a/src/features/Main/Table/index.jsx
+++ b/src/features/Main/Table/index.jsx
@@ -6,6 +6,8 @@ import {
   DataTable,
 } from '@openedx/paragon';
 
+import 'features/Main/Table/index.scss';
+
 const Table = ({
   columns,
   data,
@@ -20,17 +22,19 @@ const Table = ({
   return (
     <Row className={rowClassName}>
       <Col {...colProps}>
-        <DataTable
-          isSortable
-          columns={COLUMNS}
-          itemCount={count}
-          data={data}
-          {...props}
-        >
-          <DataTable.Table />
-          <DataTable.EmptyTable content={emptyText} />
-          <DataTable.TableFooter />
-        </DataTable>
+        <div className="responsive-data-table">
+          <DataTable
+            isSortable
+            columns={COLUMNS}
+            itemCount={count}
+            data={data}
+            {...props}
+          >
+            <DataTable.Table />
+            <DataTable.EmptyTable content={emptyText} />
+            <DataTable.TableFooter />
+          </DataTable>
+        </div>
       </Col>
     </Row>
   );

--- a/src/features/Main/Table/index.scss
+++ b/src/features/Main/Table/index.scss
@@ -1,0 +1,18 @@
+.responsive-data-table {
+  width: 100%;
+  overflow-x: auto;
+
+  .pgn__data-table-cell-wrap {
+        max-width: 15vw;
+  }
+}
+
+.responsive-data-table table {
+  width: 100%;
+  min-width: max-content;
+}
+
+.responsive-data-table td,
+.responsive-data-table th {
+  overflow-wrap: anywhere;
+}

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -28,7 +28,7 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
       return (
         <Link
           to={url}
-          className="text-truncate link"
+          className="link"
         >
           {row.values.learnerName}
         </Link>
@@ -70,7 +70,7 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
       return (
         <Link
           to={url}
-          className="text-truncate link"
+          className="link"
         >
           {row.values.className}
         </Link>
@@ -193,7 +193,7 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
             data-testid="droprown-action"
             alt="menu for actions"
           />
-          <Dropdown.Menu>
+          <Dropdown.Menu popperConfig={{ strategy: 'fixed' }}>
             <Dropdown.Item
               target="_blank"
               rel="noreferrer"


### PR DESCRIPTION
### Ticket
https://agile-jira.pearson.com/browse/PADV-3372

### Description
To make the tables in the portal responsive, if the screen is narrow, the x-scroll will be activated to prevent the table from going outside the container.

### Changes made
Use the table component to avoid code repetion
Add responsive table classes
Add property in menu dropdown to avoid the menu be hide with the scroll

### Screenshoots
Before
<img width="1569" height="588" alt="image" src="https://github.com/user-attachments/assets/2ab64dba-c024-4a36-8b4b-73482fcfe8ec" />


After
<img width="1421" height="625" alt="image" src="https://github.com/user-attachments/assets/8f1026b8-8e50-4da0-ae3c-b46059c5ba65" />


### How to test
Clone the Instructor Portal MFE
npm install
npm start