### PR TITLE
feat: modify sidebar for navy inst

### DIFF
--- a/src/features/Main/Sidebar/index.jsx
+++ b/src/features/Main/Sidebar/index.jsx
@@ -42,11 +42,15 @@ export const Sidebar = () => {
   const dispatch = useDispatch();
   const roles = getUserRoles();
   const activeTab = useSelector((state) => state.main.activeTab);
+  const institution = useSelector((state) => state.main.institution);
+
   const currentSelection = activeTab.replace(/\?institutionId=\d+/, '');
   const menuItems = [...baseItems];
   const institutionPortalPath = getConfig().INSTITUTION_PORTAL_PATH || '';
   const adminRoles = [USER_ROLES.GLOBAL_STAFF, USER_ROLES.INSTITUTION_ADMIN];
-  const institution = useSelector((state) => state.main.institution);
+  const isNavyInstitution = (
+    getConfig().NAVY_INSTITUTIONS || []
+  ).includes(institution?.uuid);
 
   if (adminRoles.some(role => roles.includes(role)) && institutionPortalPath.length > 0) {
     menuItems.push({
@@ -66,6 +70,28 @@ export const Sidebar = () => {
   };
 
   const addQueryParam = useInstitutionIdQueryParam();
+
+  const helpItems = isNavyInstitution
+    ? [
+      {
+        link: institution?.supportLink || 'https://govstore.pearsonvue.com/contact-us-ciwtcots',
+        label: 'CIWT Support Center',
+        icon: <i className="fa-regular fa-messages-question" />,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+        affix: (
+          <i className="affix-icon fa-regular fa-arrow-up-right-from-square" />
+        ),
+      },
+    ]
+    : SIDEBAR_HELP_ITEMS.map(item => (
+      item.label === 'Contact Support' && institution?.supportLink
+        ? {
+          ...item,
+          link: institution.supportLink,
+        }
+        : item
+    ));
 
   return (
     <SidebarBase>
@@ -103,25 +129,19 @@ export const Sidebar = () => {
       </MenuSection>
       <MenuSection title="Help and support">
         {
-          SIDEBAR_HELP_ITEMS.map(({
+          helpItems.map(({
             link,
             label,
             ...rest
-          }) => {
-            const resolvedLink = label === 'Contact Support' && institution?.supportLink
-              ? institution.supportLink
-              : link;
-
-            return (
-              <MenuItem
-                key={label}
-                title={label}
-                as="a"
-                href={resolvedLink}
-                {...rest}
-              />
-            );
-          })
+          }) => (
+            <MenuItem
+              key={label}
+              title={label}
+              as="a"
+              href={link}
+              {...rest}
+            />
+          ))
         }
       </MenuSection>
     </SidebarBase>


### PR DESCRIPTION
### Ticket 
https://pearson.atlassian.net/browse/PADV-3446

##  Description

This PR adds support for institution-specific Help and Support links in the sidebar.

For Navy (CIWT) institutions, the Help and Support section is customized to display a single **CIWT Support Center** link. The URL is sourced from the institution's `supportLink` attribute when available, otherwise it falls back to the default CIWT support URL.

For all other institutions, the existing Help and Support items remain unchanged. However, if an institution has a `supportLink` configured, the **Contact Support** item will use that URL instead of the default support URL.

##  Changes Made

* Added logic to identify Navy institutions using the `NAVY_INSTITUTIONS` site configuration.
* Added support for institution-specific support URLs through the institution `supportLink` attribute.
* Customized the Help and Support section for Navy institutions:

  * Removed the Knowledge Center link.
  * Replaced Contact Support with a single **CIWT Support Center** link.
  * Configured fallback behavior when `supportLink` is not available.
* Preserved existing Help and Support items for non-Navy institutions.
* Updated the Contact Support URL dynamically for non-Navy institutions when a custom `supportLink` is configured.

##  Screenshots
###  Navy Institution
<img width="545" height="602" alt="image" src="https://github.com/user-attachments/assets/13b73ce2-062d-421b-b0f7-47d65e131833" />

###  Non-Navy Institution 

<img width="648" height="646" alt="image" src="https://github.com/user-attachments/assets/d6ec3b81-5649-4621-88ca-b953366b16e5" />


## How to Test

### Scenario 1: Navy Institution

1. Configure an institution whose UUID is included in `NAVY_INSTITUTIONS` in site configurations.
2. Optionally configure the institution `supportLink`.
3. Log in and navigate to the portal.
4. Open the sidebar and expand the Help and Support section.

**Expected Results**

* Only the **CIWT Support Center** link is displayed.
* If `supportLink` is configured, the link points to that URL.
* If `supportLink` is not configured, the link points to the default CIWT support URL.

### Scenario 2: Non-Navy Institution with Custom Support Link

1. Configure an institution not included in `NAVY_INSTITUTIONS`.
2. Configure the institution `supportLink`.
3. Log in and navigate to the portal.
4. Open the sidebar and expand the Help and Support section.

**Expected Results**

* Knowledge Center is displayed.
* Contact Support is displayed.
* Contact Support points to the configured `supportLink`.

