### PR TITLE
feat: add 'Last access date' column to Classes and Students tables

### DIFF
--- a/src/features/Classes/ClassDetailPage/__test__/columns.test.jsx
+++ b/src/features/Classes/ClassDetailPage/__test__/columns.test.jsx
@@ -41,19 +41,20 @@ describe('getColumns', () => {
   test('returns an array of 11 columns with correct headers', () => {
     const cols = getColumns();
 
-    expect(cols).toHaveLength(11);
+    expect(cols).toHaveLength(12);
 
     expect(cols[0]).toHaveProperty('Header', 'Student');
     expect(cols[1]).toHaveProperty('Header', 'Email');
-    expect(cols[2]).toHaveProperty('Header', 'Institution');
-    expect(cols[3]).toHaveProperty('Header', 'Status');
-    expect(cols[4]).toHaveProperty('Header', 'Class Name');
-    expect(cols[5]).toHaveProperty('Header', 'Start - End Date');
-    expect(cols[6]).toHaveProperty('Header', 'Current Grade');
-    expect(cols[7]).toHaveProperty('Header', 'Exam Ready');
-    expect(cols[8]).toHaveProperty('Header', 'Last exam date');
-    expect(cols[9]).toHaveProperty('accessor', 'examReady.eppDaysLeft');
-    expect(cols[10]).toHaveProperty('accessor', 'classId');
+    expect(cols[2]).toHaveProperty('Header', 'Last access date');
+    expect(cols[3]).toHaveProperty('Header', 'Institution');
+    expect(cols[4]).toHaveProperty('Header', 'Status');
+    expect(cols[5]).toHaveProperty('Header', 'Class Name');
+    expect(cols[6]).toHaveProperty('Header', 'Start - End Date');
+    expect(cols[7]).toHaveProperty('Header', 'Current Grade');
+    expect(cols[8]).toHaveProperty('Header', 'Exam Ready');
+    expect(cols[9]).toHaveProperty('Header', 'Last exam date');
+    expect(cols[10]).toHaveProperty('accessor', 'examReady.eppDaysLeft');
+    expect(cols[11]).toHaveProperty('accessor', 'classId');
   });
 
   test('renders Student link', () => {
@@ -88,7 +89,7 @@ describe('getColumns', () => {
   });
 
   test('renders Status badge', () => {
-    const Cell = () => getColumns()[3].Cell({
+    const Cell = () => getColumns()[4].Cell({
       row: { values: { status: 'Active' } },
     });
 
@@ -100,7 +101,7 @@ describe('getColumns', () => {
   });
 
   test('renders Class Name with link', () => {
-    const Cell = () => getColumns()[4].Cell({
+    const Cell = () => getColumns()[5].Cell({
       row: {
         values: { className: 'test ccx1' },
         original: { classId: 'ccx-1' },
@@ -117,7 +118,7 @@ describe('getColumns', () => {
   });
 
   test('renders formatted Start - End Date', () => {
-    const Cell = () => getColumns()[5].Cell({
+    const Cell = () => getColumns()[6].Cell({
       row: {
         original: {
           startDate: '2024-02-13T17:42:22Z',
@@ -134,7 +135,7 @@ describe('getColumns', () => {
   });
 
   test('renders Current Grade correctly', () => {
-    const Cell = () => getColumns()[6].Cell({
+    const Cell = () => getColumns()[7].Cell({
       row: { values: { completePercentage: 75.5 } },
     });
 
@@ -146,7 +147,7 @@ describe('getColumns', () => {
   });
 
   test('renders Exam Ready with ProgressSteps', () => {
-    const Cell = () => getColumns()[7].Cell({
+    const Cell = () => getColumns()[8].Cell({
       row: { values: { examReady: { status: 'Complete' } } },
     });
 
@@ -158,7 +159,7 @@ describe('getColumns', () => {
   });
 
   test('renders Last exam date formatted', () => {
-    const Cell = () => getColumns()[8].Cell({
+    const Cell = () => getColumns()[9].Cell({
       row: { values: { examReady: { lastExamDate: '2024-03-15T10:00:00Z' } } },
     });
 
@@ -170,7 +171,7 @@ describe('getColumns', () => {
   });
 
   test('renders Last exam date placeholder', () => {
-    const Cell = () => getColumns()[8].Cell({
+    const Cell = () => getColumns()[9].Cell({
       row: { values: { examReady: { lastExamDate: null } } },
     });
 
@@ -182,7 +183,7 @@ describe('getColumns', () => {
   });
 
   test('renders EPP days left', () => {
-    const Cell = () => getColumns()[9].Cell({
+    const Cell = () => getColumns()[10].Cell({
       row: { values: { examReady: { eppDaysLeft: 45 } } },
     });
 
@@ -194,7 +195,7 @@ describe('getColumns', () => {
   });
 
   test('renders EPP placeholder when null', () => {
-    const Cell = () => getColumns()[9].Cell({
+    const Cell = () => getColumns()[10].Cell({
       row: { values: { examReady: { eppDaysLeft: null } } },
     });
 
@@ -206,7 +207,7 @@ describe('getColumns', () => {
   });
 
   test('action dropdown shows View progress', () => {
-    const Cell = () => getColumns()[10].Cell({
+    const Cell = () => getColumns()[11].Cell({
       row: {
         original: {
           classId: 'ccx-1',
@@ -227,7 +228,7 @@ describe('getColumns', () => {
   });
 
   test('shows DeleteEnrollment when privileged and not expired', () => {
-    const Cell = () => getColumns({ hasEnrollmentPrivilege: true })[10].Cell({
+    const Cell = () => getColumns({ hasEnrollmentPrivilege: true })[11].Cell({
       row: {
         original: {
           classId: 'ccx-1',
@@ -248,7 +249,7 @@ describe('getColumns', () => {
   });
 
   test('does NOT show DeleteEnrollment when expired', () => {
-    const Cell = () => getColumns({ hasEnrollmentPrivilege: true })[10].Cell({
+    const Cell = () => getColumns({ hasEnrollmentPrivilege: true })[11].Cell({
       row: {
         original: {
           classId: 'ccx-1',

--- a/src/features/Classes/ClassDetailPage/__test__/index.test.jsx
+++ b/src/features/Classes/ClassDetailPage/__test__/index.test.jsx
@@ -37,17 +37,18 @@ describe('getColumns (ClassDetailPage)', () => {
 
   test('returns correct column structure', () => {
     const cols = getColumns();
-    expect(cols).toHaveLength(9);
+    expect(cols).toHaveLength(10);
 
     expect(cols[0]).toHaveProperty('Header', 'No');
     expect(cols[1]).toHaveProperty('Header', 'Student');
     expect(cols[2]).toHaveProperty('Header', 'Email');
-    expect(cols[3]).toHaveProperty('Header', 'Status');
-    expect(cols[4]).toHaveProperty('Header', 'Current Grade');
-    expect(cols[5]).toHaveProperty('Header', 'Exam Ready');
-    expect(cols[6]).toHaveProperty('Header', 'Last exam date');
-    expect(cols[7]).toHaveProperty('accessor', 'examReady.eppDaysLeft');
-    expect(cols[8]).toHaveProperty('accessor', 'classId');
+    expect(cols[3]).toHaveProperty('Header', 'Last access date');
+    expect(cols[4]).toHaveProperty('Header', 'Status');
+    expect(cols[5]).toHaveProperty('Header', 'Current Grade');
+    expect(cols[6]).toHaveProperty('Header', 'Exam Ready');
+    expect(cols[7]).toHaveProperty('Header', 'Last exam date');
+    expect(cols[8]).toHaveProperty('accessor', 'examReady.eppDaysLeft');
+    expect(cols[9]).toHaveProperty('accessor', 'classId');
   });
 
   test('renders index correctly', () => {
@@ -89,8 +90,28 @@ describe('getColumns (ClassDetailPage)', () => {
     );
   });
 
+  test('renders Last access date formatted', () => {
+    const LastAccessCell = () => getColumns()[3].Cell({
+      row: { original: { lastAccess: '2024-03-15T10:00:00Z' } },
+    });
+
+    const { getByText } = renderWithProviders(<LastAccessCell />, { preloadedState: mockStore });
+
+    expect(getByText('03/15/24')).toBeInTheDocument();
+  });
+
+  test('renders Last access date placeholder when null', () => {
+    const LastAccessCell = () => getColumns()[3].Cell({
+      row: { original: { lastAccess: null } },
+    });
+
+    const { getByText } = renderWithProviders(<LastAccessCell />, { preloadedState: mockStore });
+
+    expect(getByText('--')).toBeInTheDocument();
+  });
+
   test('renders Status badge', () => {
-    const StatusCell = () => getColumns()[3].Cell({
+    const StatusCell = () => getColumns()[4].Cell({
       row: { values: { status: 'Active' } },
     });
 
@@ -100,7 +121,7 @@ describe('getColumns (ClassDetailPage)', () => {
   });
 
   test('renders Current Grade correctly', () => {
-    const GradeCell = () => getColumns()[4].Cell({
+    const GradeCell = () => getColumns()[5].Cell({
       row: { values: { completePercentage: 75.5 } },
     });
 
@@ -110,7 +131,7 @@ describe('getColumns (ClassDetailPage)', () => {
   });
 
   test('renders Exam Ready with ProgressSteps', () => {
-    const ExamReadyCell = () => getColumns()[5].Cell({
+    const ExamReadyCell = () => getColumns()[6].Cell({
       row: { values: { examReady: { status: 'Complete' } } },
     });
 
@@ -120,7 +141,7 @@ describe('getColumns (ClassDetailPage)', () => {
   });
 
   test('renders Last exam date formatted', () => {
-    const LastExamDateCell = () => getColumns()[6].Cell({
+    const LastExamDateCell = () => getColumns()[7].Cell({
       row: { values: { examReady: { lastExamDate: '2024-03-15T10:00:00Z' } } },
     });
 
@@ -130,7 +151,7 @@ describe('getColumns (ClassDetailPage)', () => {
   });
 
   test('renders Last exam date placeholder when null', () => {
-    const LastExamDateCell = () => getColumns()[6].Cell({
+    const LastExamDateCell = () => getColumns()[7].Cell({
       row: { values: { examReady: { lastExamDate: null } } },
     });
 
@@ -140,7 +161,7 @@ describe('getColumns (ClassDetailPage)', () => {
   });
 
   test('renders EPP days left value', () => {
-    const EppCell = () => getColumns()[7].Cell({
+    const EppCell = () => getColumns()[8].Cell({
       row: { values: { examReady: { eppDaysLeft: 45 } } },
     });
 
@@ -150,7 +171,7 @@ describe('getColumns (ClassDetailPage)', () => {
   });
 
   test('renders EPP days left placeholder', () => {
-    const EppCell = () => getColumns()[7].Cell({
+    const EppCell = () => getColumns()[8].Cell({
       row: { values: { examReady: { eppDaysLeft: null } } },
     });
 
@@ -160,7 +181,7 @@ describe('getColumns (ClassDetailPage)', () => {
   });
 
   test('renders actions dropdown and shows View progress', () => {
-    const ActionCell = () => getColumns()[8].Cell({
+    const ActionCell = () => getColumns()[9].Cell({
       row: {
         original: {
           classId: 'ccx-123',
@@ -179,7 +200,7 @@ describe('getColumns (ClassDetailPage)', () => {
   });
 
   test('shows DeleteEnrollment when privileged and not expired', () => {
-    const ActionCell = () => getColumns({ hasEnrollmentPrivilege: true })[8].Cell({
+    const ActionCell = () => getColumns({ hasEnrollmentPrivilege: true })[9].Cell({
       row: {
         original: {
           classId: 'ccx-123',
@@ -198,7 +219,7 @@ describe('getColumns (ClassDetailPage)', () => {
   });
 
   test('does NOT show DeleteEnrollment when expired', () => {
-    const ActionCell = () => getColumns({ hasEnrollmentPrivilege: true })[8].Cell({
+    const ActionCell = () => getColumns({ hasEnrollmentPrivilege: true })[9].Cell({
       row: {
         original: {
           classId: 'ccx-123',

--- a/src/features/Classes/ClassDetailPage/columns.jsx
+++ b/src/features/Classes/ClassDetailPage/columns.jsx
@@ -55,6 +55,16 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
     ),
   },
   {
+    Header: 'Last access date',
+    accessor: 'lastAccess',
+    Cell: ({ row }) => {
+      const lastAccess = row.original.lastAccess
+        ? formatUTCDate(row.original.lastAccess, 'MM/dd/yy')
+        : '--';
+      return <span>{lastAccess}</span>;
+    },
+  },
+  {
     Header: 'Status',
     accessor: 'status',
     Cell: ({ row }) => (

--- a/src/features/Students/StudentsPage/__test__/index.test.jsx
+++ b/src/features/Students/StudentsPage/__test__/index.test.jsx
@@ -22,7 +22,7 @@ const mockStore = {
           instructors: ['Instructor 1'],
           created: 'Fri, 25 Aug 2023 19:01:22 GMT',
           firstAccess: 'Fri, 25 Aug 2023 19:01:23 GMT',
-          lastAccess: 'Fri, 25 Aug 2023 20:20:22 GMT',
+          lastAccess: '2023-08-25T20:20:22Z',
           status: 'Active',
           examReady: {
             status: 'Complete',
@@ -40,7 +40,7 @@ const mockStore = {
           instructors: ['Instructor 2'],
           created: 'Sat, 26 Aug 2023 19:01:22 GMT',
           firstAccess: 'Sat, 26 Aug 2023 19:01:24 GMT',
-          lastAccess: 'Sat, 26 Aug 2023 21:22:22 GMT',
+          lastAccess: '2023-08-26T21:22:22Z',
           status: 'Pending',
           examReady: {
             status: 'Complete',

--- a/src/features/Students/StudentsTable/__test__/columns.test.jsx
+++ b/src/features/Students/StudentsTable/__test__/columns.test.jsx
@@ -48,11 +48,12 @@ describe('getColumns', () => {
 
   test('returns an array of columns with correct properties', () => {
     expect(getColumns()).toBeInstanceOf(Array);
-    expect(getColumns()).toHaveLength(11);
+    expect(getColumns()).toHaveLength(12);
 
     const [
       nameColumn,
       emailColumn,
+      lastAccessDateColumn,
       institutionColumn,
       statusColumn,
       classNameColumn,
@@ -69,6 +70,9 @@ describe('getColumns', () => {
 
     expect(emailColumn).toHaveProperty('Header', 'Email');
     expect(emailColumn).toHaveProperty('accessor', 'learnerEmail');
+
+    expect(lastAccessDateColumn).toHaveProperty('Header', 'Last access date');
+    expect(lastAccessDateColumn).toHaveProperty('accessor', 'lastAccess');
 
     expect(institutionColumn).toHaveProperty('Header', 'Institution');
     expect(institutionColumn).toHaveProperty('accessor', 'institutionName');
@@ -135,7 +139,7 @@ describe('getColumns', () => {
   });
 
   test('renders Status column with correct badge', () => {
-    const StatusCell = () => getColumns()[3].Cell({
+    const StatusCell = () => getColumns()[4].Cell({
       row: {
         values: { status: 'Active' },
       },
@@ -149,7 +153,7 @@ describe('getColumns', () => {
   });
 
   test('renders Class Name column with correct link', () => {
-    const ClassNameCell = () => getColumns()[4].Cell({
+    const ClassNameCell = () => getColumns()[5].Cell({
       row: {
         values: { className: 'test ccx1' },
         original: { classId: 'ccx-v1:demo+demo1+2020+ccx@3' },
@@ -171,7 +175,7 @@ describe('getColumns', () => {
   });
 
   test('renders Start - End Date column with formatted dates', () => {
-    const DateCell = () => getColumns()[5].Cell({
+    const DateCell = () => getColumns()[6].Cell({
       row: {
         original: {
           startDate: '2024-02-13T17:42:22Z',
@@ -186,7 +190,7 @@ describe('getColumns', () => {
   });
 
   test('renders Start - End Date column with empty dates', () => {
-    const DateCell = () => getColumns()[5].Cell({
+    const DateCell = () => getColumns()[6].Cell({
       row: {
         original: {
           startDate: null,
@@ -201,7 +205,7 @@ describe('getColumns', () => {
   });
 
   test('renders Progress column with percentage text', () => {
-    const ProgressCell = () => getColumns()[6].Cell({
+    const ProgressCell = () => getColumns()[7].Cell({
       row: {
         values: { completePercentage: 75.5 },
       },
@@ -213,7 +217,7 @@ describe('getColumns', () => {
   });
 
   test('renders Exam Ready column with ProgressSteps', () => {
-    const ExamReadyCell = () => getColumns()[7].Cell({
+    const ExamReadyCell = () => getColumns()[8].Cell({
       row: {
         values: {
           examReady: {
@@ -229,7 +233,7 @@ describe('getColumns', () => {
   });
 
   test('renders Last exam date with formatted date', () => {
-    const LastExamDateCell = () => getColumns()[8].Cell({
+    const LastExamDateCell = () => getColumns()[9].Cell({
       row: {
         values: {
           examReady: {
@@ -245,7 +249,7 @@ describe('getColumns', () => {
   });
 
   test('renders Last exam date with placeholder when null', () => {
-    const LastExamDateCell = () => getColumns()[8].Cell({
+    const LastExamDateCell = () => getColumns()[9].Cell({
       row: {
         values: {
           examReady: {
@@ -263,7 +267,7 @@ describe('getColumns', () => {
   test('renders EPP days left header with tooltip', () => {
     const HeaderComponent = () => {
       const columns = getColumns();
-      const { Header } = columns[9];
+      const { Header } = columns[10];
       return <Header />;
     };
 
@@ -274,7 +278,7 @@ describe('getColumns', () => {
   });
 
   test('renders EPP days left value', () => {
-    const EppDaysLeftCell = () => getColumns()[9].Cell({
+    const EppDaysLeftCell = () => getColumns()[10].Cell({
       row: {
         values: {
           examReady: {
@@ -290,7 +294,7 @@ describe('getColumns', () => {
   });
 
   test('renders EPP days left with placeholder when null', () => {
-    const EppDaysLeftCell = () => getColumns()[9].Cell({
+    const EppDaysLeftCell = () => getColumns()[10].Cell({
       row: {
         values: {
           examReady: {
@@ -306,7 +310,7 @@ describe('getColumns', () => {
   });
 
   test('shows menu dropdown with View progress link', () => {
-    const ActionColumn = () => getColumns()[10].Cell({
+    const ActionColumn = () => getColumns()[11].Cell({
       row: {
         values: {
           classId: 'ccx-v1:demo+demo1+2020+ccx@3',
@@ -337,7 +341,7 @@ describe('getColumns', () => {
   });
 
   test('shows DeleteEnrollment option when hasEnrollmentPrivilege is true and status is not expired', () => {
-    const ActionColumn = () => getColumns({ hasEnrollmentPrivilege: true })[10].Cell({
+    const ActionColumn = () => getColumns({ hasEnrollmentPrivilege: true })[11].Cell({
       row: {
         values: {
           classId: 'ccx-v1:demo+demo1+2020+ccx@3',
@@ -366,7 +370,7 @@ describe('getColumns', () => {
   });
 
   test('does not show DeleteEnrollment option when status is expired', () => {
-    const ActionColumn = () => getColumns({ hasEnrollmentPrivilege: true })[10].Cell({
+    const ActionColumn = () => getColumns({ hasEnrollmentPrivilege: true })[11].Cell({
       row: {
         values: {
           classId: 'ccx-v1:demo+demo1+2020+ccx@3',
@@ -395,7 +399,7 @@ describe('getColumns', () => {
   });
 
   test('does not show DeleteEnrollment option when hasEnrollmentPrivilege is false', () => {
-    const ActionColumn = () => getColumns({ hasEnrollmentPrivilege: false })[10].Cell({
+    const ActionColumn = () => getColumns({ hasEnrollmentPrivilege: false })[11].Cell({
       row: {
         values: {
           classId: 'ccx-v1:demo+demo1+2020+ccx@3',

--- a/src/features/Students/StudentsTable/__test__/index.test.jsx
+++ b/src/features/Students/StudentsTable/__test__/index.test.jsx
@@ -55,7 +55,7 @@ describe('Student Table', () => {
               startDate: '2023-08-25T19:01:22Z',
               endDate: '2024-08-25T19:01:22Z',
               firstAccess: 'Fri, 25 Aug 2023 19:01:23 GMT',
-              lastAccess: 'Fri, 25 Aug 2023 20:20:22 GMT',
+              lastAccess: '2023-08-25T20:20:22Z',
               status: 'Active',
               completePercentage: 75.5,
               examReady: {
@@ -78,7 +78,7 @@ describe('Student Table', () => {
               startDate: '2023-08-26T19:01:22Z',
               endDate: '2024-08-26T19:01:22Z',
               firstAccess: 'Sat, 26 Aug 2023 19:01:24 GMT',
-              lastAccess: 'Sat, 26 Aug 2023 21:22:22 GMT',
+              lastAccess: '2023-08-26T21:22:22Z',
               status: 'Pending',
               completePercentage: 45.0,
               examReady: {

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -48,6 +48,16 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
     ),
   },
   {
+    Header: 'Last access date',
+    accessor: 'lastAccess',
+    Cell: ({ row }) => {
+      const lastAccess = row.original.lastAccess
+        ? formatUTCDate(row.original.lastAccess, 'MM/dd/yy')
+        : '--';
+      return <span>{lastAccess}</span>;
+    },
+  },
+  {
     Header: 'Institution',
     accessor: 'institutionName',
   },


### PR DESCRIPTION
# Description
Adds a new "Last access date" column to both the Class Details and Students tables in the admin portal. The column is rendered immediately after the "Email" column and displays the student's last platform access date, sourced from the `last_access` field returned by the API.

## Ticket
https://pearson.atlassian.net/browse/PADV-3504

## Screenshot
<img width="1464" height="507" alt="Screenshot 2026-07-02 at 3 35 22 PM" src="https://github.com/user-attachments/assets/d809d3a9-2d7b-4a4d-bafb-15aaf5111bbc" />


**Changes**

- `features/Classes/Class/ClassPage/columns.jsx` — Added `Last access date` column (accessor: `last_access`) after the `Email` column, formatted with `formatUTCDate('MM/dd/yy')` and displaying `--` when the value is absent.
- `features/Students/StudentsTable/columns.jsx` — Same column added in the same position with identical formatting logic.

