### PR TITLE
PADV-3479 - Add a "View Class Content" action to the action menu on classes in Classes tab of the IP

### DIFF
--- a/src/features/Classes/ClassesPage/__test__/columns.test.jsx
+++ b/src/features/Classes/ClassesPage/__test__/columns.test.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { renderWithProviders } from 'test-utils';
+
+import { columns } from 'features/Classes/ClassesPage/columns';
+
+jest.mock('features/Main/ActionsDropdown', () => jest.fn(() => <div data-testid="actions-dropdown" />));
+
+jest.mock('features/Classes/EnrollStudent', () => function EnrollStudent() {
+  return <div data-testid="enroll-student" />;
+});
+
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(() => ({
+    LEARNING_MICROFRONTEND_URL: 'http://localhost:2000',
+    GRADEBOOK_MICROFRONTEND_URL: '',
+    LMS_BASE_URL: '',
+  })),
+}));
+
+jest.mock('@openedx/paragon', () => ({
+  // eslint-disable-next-line react/prop-types
+  Toast: function MockToast({ show, children }) {
+    return show ? <div>{children}</div> : null;
+  },
+}));
+
+describe('ClassesPage columns', () => {
+  test('adds View class content as the first action', () => {
+    const ActionColumn = () => columns[8].Cell({
+      row: {
+        values: {},
+        original: {
+          classId: 'class-1',
+          className: 'Class 1',
+          labSummaryTag: null,
+        },
+      },
+    });
+
+    renderWithProviders(<ActionColumn />, {
+      preloadedState: {
+        instructor: {
+          info: {},
+        },
+      },
+      initialEntries: ['/classes'],
+    });
+
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const mockActionsDropdown = require('features/Main/ActionsDropdown').default || require('features/Main/ActionsDropdown');
+    const [props] = mockActionsDropdown.mock.calls[0];
+
+    expect(props.options).toHaveLength(4);
+    expect(props.options[0]).toMatchObject({
+      label: 'View class content',
+      visible: true,
+    });
+  });
+});

--- a/src/features/Classes/ClassesPage/columns.jsx
+++ b/src/features/Classes/ClassesPage/columns.jsx
@@ -103,7 +103,21 @@ const columns = [
 
       const handleEnrollStudentModal = () => setIsEnrollModalOpen(!isEnrollModalOpen);
 
+      const handleViewClassContent = () => {
+        window.open(
+          `${getConfig().LEARNING_MICROFRONTEND_URL}/course/${classId}/home`,
+          '_blank',
+          'noopener,noreferrer',
+        );
+      };
+
       const extraOptions = [
+        {
+          handleClick: handleViewClassContent,
+          iconSrc: <i className="fa-regular fa-eye mr-3" />,
+          label: 'View class content',
+          visible: true,
+        },
         {
           handleClick: handleGradebookButton,
           iconSrc: <i className="fa-regular fa-book mr-3" />,


### PR DESCRIPTION
# Description
Add "View Class Content" action as the first menu item in the Classes table action dropdown on the Instructor Portal, allowing instructors to directly access class content from the Classes tab without having to drill into the class details.

## Ticket
https://pearson.atlassian.net/browse/PADV-3479

###  Changes
- **File**: `src/features/Classes/ClassesPage/columns.jsx`
  - Added `handleViewClassContent()` function to open the learning MFE class content page in a new tab
  - Added "View class content" as the **first item** in the `extraOptions` array for the action dropdown
  - Icon: `fa-regular fa-eye` (matching admin portal implementation)

- **File**: `src/features/Classes/ClassesPage/__test__/columns.test.jsx` (new)
  - Created focused unit test to verify the "View class content" action is configured as the first option
  - Test validates correct label, visibility, and position in the dropdown menu

