### PR TITLE
feat: update EnrollStudent tests

### DIFF
--- a/src/features/Classes/EnrollStudent/__test__/index.test.jsx
+++ b/src/features/Classes/EnrollStudent/__test__/index.test.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { renderWithProviders } from 'test-utils';
-import { fireEvent, waitFor, act } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import * as router from 'react-router-dom';
 
 import EnrollStudent from 'features/Classes/EnrollStudent';
 
 import * as api from 'features/Classes/data/api';
+import { fetchStudentsData } from 'features/Students/data';
+import { fetchAllClassesData } from 'features/Common/data';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -17,6 +19,16 @@ jest.mock('features/Classes/data/api', () => ({
   getMessages: jest.fn(),
 }));
 
+jest.mock('features/Students/data', () => ({
+  ...jest.requireActual('features/Students/data'),
+  fetchStudentsData: jest.fn(() => ({ type: 'FETCH_STUDENTS' })),
+}));
+
+jest.mock('features/Common/data', () => ({
+  ...jest.requireActual('features/Common/data'),
+  fetchAllClassesData: jest.fn(() => ({ type: 'FETCH_CLASSES' })),
+}));
+
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
 }));
@@ -25,7 +37,7 @@ jest.mock('@openedx/paragon', () => {
   /* eslint-disable react/prop-types */
   const actual = jest.requireActual('@openedx/paragon');
 
-  const Toast = ({ children, show }) => (show ? <div data-testid="toast-message">{children}</div> : null);
+  const Toast = ({ children, show, ...props }) => (show ? <div {...props}>{children}</div> : null);
 
   const Spinner = () => <div data-testid="spinner" />;
 
@@ -37,19 +49,25 @@ jest.mock('@openedx/paragon', () => {
 });
 
 describe('EnrollStudent', () => {
+  const mockState = {
+    main: {
+      username: 'demo_instructor',
+      institution: { id: 456, name: 'Demo Institution' },
+    },
+  };
+
   beforeEach(() => {
     router.useParams.mockReturnValue({ classId: 'ccx1' });
   });
 
   afterEach(() => {
     jest.clearAllMocks();
-    jest.resetAllMocks();
   });
 
   test('Should render with correct elements', () => {
     const { getByText, getByPlaceholderText } = renderWithProviders(
       <EnrollStudent isOpen onClose={() => {}} className="demo class" />,
-      { preloadedState: {} },
+      { preloadedState: mockState },
     );
 
     expect(getByText('Invite student to enroll')).toBeInTheDocument();
@@ -58,22 +76,27 @@ describe('EnrollStudent', () => {
     expect(getByText('Send invite')).toBeInTheDocument();
   });
 
-  // Review the test
-  test.skip('Should handle form submission and shows success toast', async () => {
+  test('Should handle form submission and shows success toast', async () => {
     const onCloseMock = jest.fn();
 
-    const { getByPlaceholderText, getByText, getByTestId } = renderWithProviders(
-      <EnrollStudent isOpen onClose={onCloseMock} className="demo class" />,
-      { preloadedState: {} },
-    );
-
-    const handleEnrollmentsMock = jest.spyOn(api, 'handleEnrollments').mockResolvedValue({
+    api.handleEnrollments.mockResolvedValue({
       data: {
         results: [{
           identifier: 'test@example.com',
         }],
       },
     });
+
+    api.getMessages.mockResolvedValue({
+      data: {
+        results: [],
+      },
+    });
+
+    const { getByPlaceholderText, getByText, getByTestId } = renderWithProviders(
+      <EnrollStudent isOpen onClose={onCloseMock} className="demo class" />,
+      { preloadedState: mockState },
+    );
 
     const emailInput = getByPlaceholderText('Enter email of the student to enroll');
     fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
@@ -82,15 +105,28 @@ describe('EnrollStudent', () => {
     fireEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(getByTestId('toast-message').textContent).toBe('Successfully enrolled and sent email to the following user:\ntest@example.com');
+      expect(getByTestId('toast-message')).toHaveTextContent(/Successfully enrolled and sent email to the following user:\s*test@example\.com/);
     });
 
-    expect(handleEnrollmentsMock).toHaveBeenCalledTimes(1);
-    handleEnrollmentsMock.mockRestore();
+    expect(api.handleEnrollments).toHaveBeenCalledTimes(1);
+    expect(api.getMessages).toHaveBeenCalledTimes(1);
+    expect(fetchStudentsData).toHaveBeenCalledWith(
+      'demo_instructor',
+      expect.objectContaining({
+        class_name: 'demo class',
+        institution_id: 456,
+        limit: true,
+        page: 1,
+      }),
+    );
+    expect(fetchAllClassesData).toHaveBeenCalledWith(
+      'demo_instructor',
+      { class_id: 'ccx1', institution_id: 456 },
+    );
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
   });
 
-  // Review the test
-  test.skip('Should handle form submission and show error toast', async () => {
+  test('Should handle form submission and show error toast', async () => {
     const onCloseMock = jest.fn();
 
     api.handleEnrollments.mockResolvedValue({
@@ -105,7 +141,7 @@ describe('EnrollStudent', () => {
 
     const { getByPlaceholderText, getByText, getByTestId } = renderWithProviders(
       <EnrollStudent isOpen onClose={onCloseMock} className="demo class" />,
-      { preloadedState: {} },
+      { preloadedState: mockState },
     );
 
     const emailInput = getByPlaceholderText('Enter email of the student to enroll');
@@ -118,11 +154,14 @@ describe('EnrollStudent', () => {
       expect(getByTestId('toast-message')).toHaveTextContent('Enrollment limit reached');
     });
 
+    expect(api.handleEnrollments).toHaveBeenCalledTimes(1);
     expect(api.getMessages).toHaveBeenCalledTimes(1);
+    expect(fetchStudentsData).not.toHaveBeenCalled();
+    expect(fetchAllClassesData).not.toHaveBeenCalled();
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
   });
 
-  // Review test
-  test.skip('Should handle form submission and show error toast for invalid email', async () => {
+  test('Should handle form submission and show error toast for invalid email', async () => {
     const onCloseMock = jest.fn();
 
     api.handleEnrollments.mockResolvedValue({
@@ -134,19 +173,16 @@ describe('EnrollStudent', () => {
       },
     });
 
-    const { getByPlaceholderText, getByText, getByTestId } = renderWithProviders(
-      <EnrollStudent isOpen onClose={onCloseMock} className="demo class" />,
-      { preloadedState: {} },
-    );
-
-    const handleEnrollmentsMock = jest.spyOn(api, 'handleEnrollments').mockResolvedValue({
+    api.getMessages.mockResolvedValue({
       data: {
-        results: [{
-          identifier: 'test@example.com',
-          invalidIdentifier: true,
-        }],
+        results: [],
       },
     });
+
+    const { getByPlaceholderText, getByText, getByTestId } = renderWithProviders(
+      <EnrollStudent isOpen onClose={onCloseMock} className="demo class" />,
+      { preloadedState: mockState },
+    );
 
     const emailInput = getByPlaceholderText('Enter email of the student to enroll');
     fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
@@ -154,14 +190,25 @@ describe('EnrollStudent', () => {
     const submitButton = getByText('Send invite');
     fireEvent.click(submitButton);
 
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(getByTestId('toast-message')).toHaveTextContent(/The following email adress is invalid:\s*test@example\.com/);
     });
 
-    expect(getByTestId('toast-message').textContent).toBe('The following email adress is invalid:\ntest@example.com\n');
-
-    expect(handleEnrollmentsMock).toHaveBeenCalledTimes(1);
-    handleEnrollmentsMock.mockRestore();
+    expect(api.handleEnrollments).toHaveBeenCalledTimes(1);
+    expect(api.getMessages).toHaveBeenCalledTimes(1);
+    expect(fetchStudentsData).toHaveBeenCalledWith(
+      'demo_instructor',
+      expect.objectContaining({
+        class_name: 'demo class',
+        institution_id: 456,
+        limit: true,
+        page: 1,
+      }),
+    );
+    expect(fetchAllClassesData).toHaveBeenCalledWith(
+      'demo_instructor',
+      { class_id: 'ccx1', institution_id: 456 },
+    );
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
# Description

Re-enable the skipped Enroll Student tests and update them to match the current component behavior.

This change:
- Restores coverage for the success, backend error, and invalid email flows.
- Updates test mocks to preserve real module exports while overriding the thunk creators used in assertions.
- Makes toast assertions resilient to rendered whitespace differences.
- Removes mock reset behavior that was clearing required test implementations between cases.

## Testing

- `npx jest src/features/Classes/EnrollStudent/__test__/index.test.jsx --runInBand`
- `npm test -- --runInBand`
