### PR TITLE
feat: update Last access date handling for pending enrollments 

### DIFF
--- a/src/features/Classes/ClassDetailPage/__test__/index.test.jsx
+++ b/src/features/Classes/ClassDetailPage/__test__/index.test.jsx
@@ -110,6 +110,16 @@ describe('getColumns (ClassDetailPage)', () => {
     expect(getByText('--')).toBeInTheDocument();
   });
 
+  test('renders Last access date as -- when enrollment is pending', () => {
+    const LastAccessCell = () => getColumns()[3].Cell({
+      row: { original: { lastAccess: '2024-03-15T10:00:00Z', status: 'pending' } },
+    });
+
+    const { getByText } = renderWithProviders(<LastAccessCell />, { preloadedState: mockStore });
+
+    expect(getByText('--')).toBeInTheDocument();
+  });
+
   test('renders Status badge', () => {
     const StatusCell = () => getColumns()[4].Cell({
       row: { values: { status: 'Active' } },

--- a/src/features/Classes/ClassDetailPage/columns.jsx
+++ b/src/features/Classes/ClassDetailPage/columns.jsx
@@ -58,7 +58,8 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
     Header: 'Last access date',
     accessor: 'lastAccess',
     Cell: ({ row }) => {
-      const lastAccess = row.original.lastAccess
+      const isPending = row.original.status?.toLowerCase() === 'pending';
+      const lastAccess = !isPending && row.original.lastAccess
         ? formatUTCDate(row.original.lastAccess, 'MM/dd/yy')
         : '--';
       return <span>{lastAccess}</span>;

--- a/src/features/Students/StudentsTable/__test__/columns.test.jsx
+++ b/src/features/Students/StudentsTable/__test__/columns.test.jsx
@@ -138,6 +138,36 @@ describe('getColumns', () => {
     expect(link).toHaveAttribute('href', 'mailto:testuser@example.com');
   });
 
+  test('renders Last access date formatted', () => {
+    const LastAccessCell = () => getColumns()[2].Cell({
+      row: { original: { lastAccess: '2024-03-15T10:00:00Z', status: 'Active' } },
+    });
+
+    const { getByText } = renderWithProviders(<LastAccessCell />, { preloadedState: mockStore });
+
+    expect(getByText('03/15/24')).toBeInTheDocument();
+  });
+
+  test('renders Last access date as -- when enrollment is pending', () => {
+    const LastAccessCell = () => getColumns()[2].Cell({
+      row: { original: { lastAccess: '2024-03-15T10:00:00Z', status: 'pending' } },
+    });
+
+    const { getByText } = renderWithProviders(<LastAccessCell />, { preloadedState: mockStore });
+
+    expect(getByText('--')).toBeInTheDocument();
+  });
+
+  test('renders Last access date as -- when null', () => {
+    const LastAccessCell = () => getColumns()[2].Cell({
+      row: { original: { lastAccess: null, status: 'Active' } },
+    });
+
+    const { getByText } = renderWithProviders(<LastAccessCell />, { preloadedState: mockStore });
+
+    expect(getByText('--')).toBeInTheDocument();
+  });
+
   test('renders Status column with correct badge', () => {
     const StatusCell = () => getColumns()[4].Cell({
       row: {

--- a/src/features/Students/StudentsTable/columns.jsx
+++ b/src/features/Students/StudentsTable/columns.jsx
@@ -51,7 +51,8 @@ const getColumns = ({ hasEnrollmentPrivilege = false } = {}) => [
     Header: 'Last access date',
     accessor: 'lastAccess',
     Cell: ({ row }) => {
-      const lastAccess = row.original.lastAccess
+      const isPending = row.original.status?.toLowerCase() === 'pending';
+      const lastAccess = !isPending && row.original.lastAccess
         ? formatUTCDate(row.original.lastAccess, 'MM/dd/yy')
         : '--';
       return <span>{lastAccess}</span>;


### PR DESCRIPTION
# Description
When a student's enrollment status is pending, the Last access date column was displaying a date that does not correspond to an actual course access. This fix ensures the column renders -- instead of a date for pending enrollments.

Changes
- Added a pending status check in the Last access date Cell renderer for the Students and Classes tables.
- The column now renders -- when row.original.status is 'pending', regardless of the lastAccess value.

Files changed
- src/features/Students/StudentsTable/columns.jsx
- src/features/Classes/ClassDetailPage/columns.jsx 

## Before
<img width="1372" height="175" alt="Screenshot 2026-07-08 at 3 09 42 PM" src="https://github.com/user-attachments/assets/1f8f56d4-a112-482b-a5e5-858814bf4cc0" />

## After
<img width="1412" height="565" alt="Screenshot 2026-07-08 at 3 06 04 PM" src="https://github.com/user-attachments/assets/007f0844-d5f3-4ad7-99ae-92b20663986e" />