### PR TITLE
PADV-3531 - Make gradebook download available from action menu of a class

### DIFF
--- a/src/features/Classes/ClassDetailPage/__test__/downloadGradebook.test.jsx
+++ b/src/features/Classes/ClassDetailPage/__test__/downloadGradebook.test.jsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { act } from '@testing-library/react';
+import { Route } from 'react-router-dom';
+
+import { renderWithProviders } from 'test-utils';
+
+import ClassDetailPage from 'features/Classes/ClassDetailPage';
+import { fetchGradebookCsv } from 'features/Classes/data/api';
+import { downloadFileFromBlob } from 'helpers';
+import { RequestStatus } from 'features/constants';
+
+jest.mock('features/Classes/ClassDetailPage/InstructorCard', () => function InstructorCard() {
+  return <div data-testid="instructor-card" />;
+});
+
+jest.mock('features/Classes/EnrollStudent', () => function EnrollStudent() {
+  return <div data-testid="enroll-student" />;
+});
+
+jest.mock('features/Main/ActionsDropdown', () => jest.fn(() => <div data-testid="actions-dropdown" />));
+
+jest.mock('features/Classes/data/api', () => ({
+  fetchGradebookCsv: jest.fn(),
+}));
+
+jest.mock('helpers', () => ({
+  ...jest.requireActual('helpers'),
+  downloadFileFromBlob: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(() => ({
+    LEARNING_MICROFRONTEND_URL: 'http://localhost:2000',
+    GRADEBOOK_MICROFRONTEND_URL: '',
+    LMS_BASE_URL: '',
+  })),
+}));
+
+const classId = 'ccx-v1:demo+demo1+2020+ccx@40';
+
+const mockStore = {
+  main: {
+    username: 'instructor123',
+    institution: { id: 1 },
+  },
+  common: {
+    allClasses: {
+      status: RequestStatus.SUCCESS,
+      data: [
+        {
+          className: 'Demo Class',
+          classId,
+          labSummaryTag: null,
+        },
+      ],
+    },
+  },
+  students: {
+    table: {
+      status: RequestStatus.SUCCESS,
+      data: [],
+      count: 0,
+      numPages: 1,
+    },
+  },
+  instructor: {
+    info: { hasEnrollmentPrivilege: false },
+  },
+};
+
+const renderPage = () => renderWithProviders(
+  <Route path="/classes/:classId" element={<ClassDetailPage />} />,
+  {
+    preloadedState: mockStore,
+    initialEntries: [`/classes/${classId}`],
+  },
+);
+
+const getLatestOptions = () => {
+  const mockActionsDropdown = require('features/Main/ActionsDropdown').default || require('features/Main/ActionsDropdown'); // eslint-disable-line global-require, import/no-dynamic-require
+  return mockActionsDropdown.mock.calls[mockActionsDropdown.mock.calls.length - 1][0].options;
+};
+
+describe('ClassDetailPage - Download Gradebook action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('adds Download Gradebook alongside the Gradebook action', () => {
+    renderPage();
+
+    const options = getLatestOptions();
+
+    expect(options[0]).toMatchObject({ label: 'Gradebook', visible: true });
+    expect(options[1]).toMatchObject({ label: 'Download Gradebook', visible: true, disabled: false });
+  });
+
+  test('downloads the gradebook CSV using the ccx course id and blocks duplicate clicks', async () => {
+    let resolveRequest;
+    fetchGradebookCsv.mockReturnValue(new Promise((resolve) => { resolveRequest = resolve; }));
+
+    renderPage();
+
+    let downloadPromise;
+    act(() => {
+      downloadPromise = getLatestOptions()[1].handleClick();
+    });
+
+    // Clicking again while the request is in flight should be ignored.
+    act(() => {
+      getLatestOptions()[1].handleClick();
+    });
+
+    expect(fetchGradebookCsv).toHaveBeenCalledTimes(1);
+    expect(fetchGradebookCsv).toHaveBeenCalledWith(classId);
+
+    await act(async () => {
+      resolveRequest({ data: 'csv,data' });
+      await downloadPromise;
+    });
+
+    expect(downloadFileFromBlob).toHaveBeenCalledWith('csv,data', `${classId}-ccx-grades.csv`);
+  });
+
+  test('shows an error message when the gradebook download fails', async () => {
+    fetchGradebookCsv.mockRejectedValue(new Error('network error'));
+
+    const { findByText } = renderPage();
+
+    await act(async () => {
+      await getLatestOptions()[1].handleClick();
+    });
+
+    expect(await findByText('An error occurred while downloading the gradebook. Please try again.')).toBeInTheDocument();
+  });
+});

--- a/src/features/Classes/ClassDetailPage/index.jsx
+++ b/src/features/Classes/ClassDetailPage/index.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { getConfig } from '@edx/frontend-platform';
+import { logError } from '@edx/frontend-platform/logging';
 
 import Table from 'features/Main/Table';
 import { Button } from 'react-paragon-topaz';
@@ -13,6 +14,7 @@ import {
 
 import { useInstitutionIdQueryParam, useToast } from 'hooks';
 import { fetchLabSummaryLink } from 'features/Classes/data/thunks';
+import { fetchGradebookCsv } from 'features/Classes/data/api';
 import InstructorCard from 'features/Classes/ClassDetailPage/InstructorCard';
 import EnrollStudent from 'features/Classes/EnrollStudent';
 
@@ -24,7 +26,7 @@ import { fetchAllClassesData } from 'features/Common/data';
 import ActionsDropdown from 'features/Main/ActionsDropdown';
 import { getColumns } from 'features/Classes/ClassDetailPage/columns';
 import { RequestStatus, initialPage } from 'features/constants';
-import { isInvalidUserOrInstitution } from 'helpers';
+import { isInvalidUserOrInstitution, downloadFileFromBlob } from 'helpers';
 
 import 'features/Classes/ClassDetailPage/index.scss';
 
@@ -57,6 +59,7 @@ const ClassDetailPage = () => {
 
   const [currentPage, setCurrentPage] = useState(initialPage);
   const [isEnrollModalOpen, setIsEnrollModalOpen] = useState(false);
+  const [isDownloadingGradebook, setIsDownloadingGradebook] = useState(false);
 
   const isLoading = students.status === RequestStatus.LOADING;
   const className = (classInfo?.className || '');
@@ -107,6 +110,24 @@ const ClassDetailPage = () => {
     window.open(`${gradebookUrl}/gradebook/${classId}`, '_blank', 'noopener,noreferrer');
   };
 
+  const handleDownloadGradebook = async () => {
+    if (isDownloadingGradebook) { return; }
+
+    setIsDownloadingGradebook(true);
+    showToast('Downloading gradebook. This may take a moment, please wait...');
+
+    try {
+      const response = await fetchGradebookCsv(classId);
+      downloadFileFromBlob(response.data, `${classId}-ccx-grades.csv`);
+      hideToast();
+    } catch (error) {
+      showToast('An error occurred while downloading the gradebook. Please try again.');
+      logError(error);
+    } finally {
+      setIsDownloadingGradebook(false);
+    }
+  };
+
   const handleLabSummary = () => {
     dispatch(fetchLabSummaryLink(classId, classInfo?.labSummaryTag, (dashboardMessage) => {
       showToast(dashboardMessage);
@@ -119,6 +140,13 @@ const ClassDetailPage = () => {
       iconSrc: <i className="fa-regular fa-book mr-3" />,
       label: 'Gradebook',
       visible: true,
+    },
+    {
+      handleClick: handleDownloadGradebook,
+      iconSrc: <i className="fa-solid fa-download mr-3" />,
+      label: 'Download Gradebook',
+      visible: true,
+      disabled: isDownloadingGradebook,
     },
     {
       handleClick: handleLabSummary,

--- a/src/features/Classes/ClassesPage/__test__/columns.test.jsx
+++ b/src/features/Classes/ClassesPage/__test__/columns.test.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { act } from '@testing-library/react';
 
 import { renderWithProviders } from 'test-utils';
 
 import { columns } from 'features/Classes/ClassesPage/columns';
+import { fetchGradebookCsv } from 'features/Classes/data/api';
+import { downloadFileFromBlob } from 'helpers';
 
 jest.mock('features/Main/ActionsDropdown', () => jest.fn(() => <div data-testid="actions-dropdown" />));
 
@@ -10,12 +13,24 @@ jest.mock('features/Classes/EnrollStudent', () => function EnrollStudent() {
   return <div data-testid="enroll-student" />;
 });
 
+jest.mock('features/Classes/data/api', () => ({
+  fetchGradebookCsv: jest.fn(),
+}));
+
+jest.mock('helpers', () => ({
+  downloadFileFromBlob: jest.fn(),
+}));
+
 jest.mock('@edx/frontend-platform', () => ({
   getConfig: jest.fn(() => ({
     LEARNING_MICROFRONTEND_URL: 'http://localhost:2000',
     GRADEBOOK_MICROFRONTEND_URL: '',
     LMS_BASE_URL: '',
   })),
+}));
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
 }));
 
 jest.mock('@openedx/paragon', () => ({
@@ -26,6 +41,10 @@ jest.mock('@openedx/paragon', () => ({
 }));
 
 describe('ClassesPage columns', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('adds View class content as the first action', () => {
     const ActionColumn = () => columns[8].Cell({
       row: {
@@ -51,10 +70,130 @@ describe('ClassesPage columns', () => {
     const mockActionsDropdown = require('features/Main/ActionsDropdown').default || require('features/Main/ActionsDropdown');
     const [props] = mockActionsDropdown.mock.calls[0];
 
-    expect(props.options).toHaveLength(4);
+    expect(props.options).toHaveLength(5);
     expect(props.options[0]).toMatchObject({
       label: 'View class content',
       visible: true,
     });
+  });
+
+  test('adds Download Gradebook alongside Gradebook action', () => {
+    const ActionColumn = () => columns[8].Cell({
+      row: {
+        values: {},
+        original: {
+          classId: 'class-1',
+          className: 'Class 1',
+          labSummaryTag: null,
+        },
+      },
+    });
+
+    renderWithProviders(<ActionColumn />, {
+      preloadedState: {
+        instructor: {
+          info: {},
+        },
+      },
+      initialEntries: ['/classes'],
+    });
+
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const mockActionsDropdown = require('features/Main/ActionsDropdown').default || require('features/Main/ActionsDropdown');
+    const [props] = mockActionsDropdown.mock.calls[0];
+
+    expect(props.options[1]).toMatchObject({
+      label: 'Gradebook',
+      visible: true,
+    });
+    expect(props.options[2]).toMatchObject({
+      label: 'Download Gradebook',
+      visible: true,
+      disabled: false,
+    });
+  });
+
+  test('downloads the gradebook CSV using the decoded class id and blocks duplicate clicks', async () => {
+    let resolveRequest;
+    fetchGradebookCsv.mockReturnValue(new Promise((resolve) => { resolveRequest = resolve; }));
+
+    const ActionColumn = () => columns[8].Cell({
+      row: {
+        values: {},
+        original: {
+          classId: 'class-1%40demo',
+          className: 'Class 1',
+          labSummaryTag: null,
+        },
+      },
+    });
+
+    renderWithProviders(<ActionColumn />, {
+      preloadedState: {
+        instructor: {
+          info: {},
+        },
+      },
+      initialEntries: ['/classes'],
+    });
+
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const mockActionsDropdown = require('features/Main/ActionsDropdown').default || require('features/Main/ActionsDropdown');
+    const getLatestOptions = () => mockActionsDropdown.mock.calls[mockActionsDropdown.mock.calls.length - 1][0].options;
+
+    let downloadPromise;
+    act(() => {
+      downloadPromise = getLatestOptions()[2].handleClick();
+    });
+
+    // Clicking again while the request is in flight should be ignored.
+    act(() => {
+      getLatestOptions()[2].handleClick();
+    });
+
+    expect(fetchGradebookCsv).toHaveBeenCalledTimes(1);
+    expect(fetchGradebookCsv).toHaveBeenCalledWith('class-1@demo');
+
+    await act(async () => {
+      resolveRequest({ data: 'csv,data' });
+      await downloadPromise;
+    });
+
+    expect(downloadFileFromBlob).toHaveBeenCalledWith('csv,data', 'class-1@demo-ccx-grades.csv');
+  });
+
+  test('shows an error message when the gradebook download fails', async () => {
+    fetchGradebookCsv.mockRejectedValue(new Error('network error'));
+
+    const ActionColumn = () => columns[8].Cell({
+      row: {
+        values: {},
+        original: {
+          classId: 'class-1',
+          className: 'Class 1',
+          labSummaryTag: null,
+        },
+      },
+    });
+
+    const { findByText } = renderWithProviders(<ActionColumn />, {
+      preloadedState: {
+        instructor: {
+          info: {},
+        },
+      },
+      initialEntries: ['/classes'],
+    });
+
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const mockActionsDropdown = require('features/Main/ActionsDropdown').default || require('features/Main/ActionsDropdown');
+    const [props] = mockActionsDropdown.mock.calls[0];
+    const { handleClick } = props.options[2];
+
+    await act(async () => {
+      await handleClick();
+    });
+
+    expect(await findByText('An error occurred while downloading the gradebook. Please try again.')).toBeInTheDocument();
   });
 });

--- a/src/features/Classes/ClassesPage/columns.jsx
+++ b/src/features/Classes/ClassesPage/columns.jsx
@@ -4,11 +4,14 @@ import { Link } from 'react-router-dom';
 import { formatUTCDate } from 'react-paragon-topaz';
 import { useSelector, useDispatch } from 'react-redux';
 import { getConfig } from '@edx/frontend-platform';
+import { logError } from '@edx/frontend-platform/logging';
 import { Toast } from '@openedx/paragon';
 
 import { useInstitutionIdQueryParam, useToast } from 'hooks';
+import { downloadFileFromBlob } from 'helpers';
 
 import { fetchLabSummaryLink } from 'features/Classes/data/thunks';
+import { fetchGradebookCsv } from 'features/Classes/data/api';
 import EnrollStudent from 'features/Classes/EnrollStudent';
 import ActionsDropdown from 'features/Main/ActionsDropdown';
 
@@ -89,10 +92,30 @@ const columns = [
       } = useToast();
 
       const [isEnrollModalOpen, setIsEnrollModalOpen] = useState(false);
+      const [isDownloadingGradebook, setIsDownloadingGradebook] = useState(false);
+
+      const decodedClassId = decodeURIComponent(classId);
 
       const handleGradebookButton = () => {
-        const decodedClassId = decodeURIComponent(classId);
         window.open(`${gradebookUrl}/gradebook/${decodedClassId}`, '_blank', 'noopener,noreferrer');
+      };
+
+      const handleDownloadGradebook = async () => {
+        if (isDownloadingGradebook) { return; }
+
+        setIsDownloadingGradebook(true);
+        showToast('Downloading gradebook. This may take a moment, please wait...');
+
+        try {
+          const response = await fetchGradebookCsv(decodedClassId);
+          downloadFileFromBlob(response.data, `${decodedClassId}-ccx-grades.csv`);
+          hideToast();
+        } catch (error) {
+          showToast('An error occurred while downloading the gradebook. Please try again.');
+          logError(error);
+        } finally {
+          setIsDownloadingGradebook(false);
+        }
       };
 
       const handleLabSummary = () => {
@@ -123,6 +146,13 @@ const columns = [
           iconSrc: <i className="fa-regular fa-book mr-3" />,
           label: 'Gradebook',
           visible: true,
+        },
+        {
+          handleClick: handleDownloadGradebook,
+          iconSrc: <i className="fa-solid fa-download mr-3" />,
+          label: 'Download Gradebook',
+          visible: true,
+          disabled: isDownloadingGradebook,
         },
         {
           handleClick: handleLabSummary,

--- a/src/features/Classes/data/__test__/api.test.js
+++ b/src/features/Classes/data/__test__/api.test.js
@@ -1,5 +1,5 @@
 import {
-  handleEnrollments, getMessages, handleSkillableDashboard, handleXtremeLabsDashboard,
+  handleEnrollments, getMessages, handleSkillableDashboard, handleXtremeLabsDashboard, fetchGradebookCsv,
 } from 'features/Classes/data/api';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
@@ -106,6 +106,32 @@ describe('handleXtremeLabsDashboard', () => {
     expect(httpClientMock.post).toHaveBeenCalledWith(
       'http://localhost:18000/xtreme_labs_plugin/course-tab/api/v1/instructor-dashboard-launch/',
       { class_id: courseId },
+    );
+  });
+});
+
+describe('fetchGradebookCsv', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should call getAuthenticatedHttpClient with the correct parameters', () => {
+    const httpClientMock = {
+      get: jest.fn().mockResolvedValue({}),
+    };
+    const ccxCourseId = 'ccx-v1:demo+demo1+2020+ccx@1';
+
+    getAuthenticatedHttpClient.mockReturnValue(httpClientMock);
+
+    fetchGradebookCsv(ccxCourseId);
+
+    expect(getAuthenticatedHttpClient).toHaveBeenCalledTimes(1);
+    expect(getAuthenticatedHttpClient).toHaveBeenCalledWith();
+
+    expect(httpClientMock.get).toHaveBeenCalledTimes(1);
+    expect(httpClientMock.get).toHaveBeenCalledWith(
+      'http://localhost:18000/courses/ccx-v1:demo+demo1+2020+ccx@1/ccx_grades.csv',
+      { responseType: 'blob' },
     );
   });
 });

--- a/src/features/Classes/data/api.js
+++ b/src/features/Classes/data/api.js
@@ -34,9 +34,16 @@ function handleXtremeLabsDashboard(courseId) {
   );
 }
 
+function fetchGradebookCsv(ccxCourseId) {
+  const GRADEBOOK_CSV_URL = `${getConfig().LMS_BASE_URL}/courses/${ccxCourseId}/ccx_grades.csv`;
+
+  return getAuthenticatedHttpClient().get(GRADEBOOK_CSV_URL, { responseType: 'blob' });
+}
+
 export {
   handleEnrollments,
   getMessages,
   handleSkillableDashboard,
   handleXtremeLabsDashboard,
+  fetchGradebookCsv,
 };

--- a/src/features/Main/ActionsDropdown/Option.jsx
+++ b/src/features/Main/ActionsDropdown/Option.jsx
@@ -1,8 +1,10 @@
 import { Dropdown } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 
-const Option = ({ iconSrc, handleClick, label }) => (
-  <Dropdown.Item onClick={handleClick}>
+const Option = ({
+  iconSrc, handleClick, label, disabled,
+}) => (
+  <Dropdown.Item onClick={handleClick} disabled={disabled}>
     {iconSrc}
     {label}
   </Dropdown.Item>
@@ -10,12 +12,14 @@ const Option = ({ iconSrc, handleClick, label }) => (
 
 Option.defaultProps = {
   iconSrc: '',
+  disabled: false,
 };
 
 Option.propTypes = {
   iconSrc: PropTypes.string,
   handleClick: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
 };
 
 export default Option;

--- a/src/features/Main/ActionsDropdown/__test__/index.test.jsx
+++ b/src/features/Main/ActionsDropdown/__test__/index.test.jsx
@@ -38,4 +38,22 @@ describe('ActionsDropdown', () => {
     expect(optionsMock[0].handleClick).toHaveBeenCalledTimes(1);
     expect(optionsMock[1].handleClick).not.toHaveBeenCalled();
   });
+
+  test('Should not call handleClick when the option is disabled', () => {
+    const disabledOptionsMock = [
+      {
+        handleClick: jest.fn(), label: 'Disabled option', visible: true, disabled: true,
+      },
+    ];
+
+    const { getByLabelText, getByText } = render(<ActionsDropdown options={disabledOptionsMock} />);
+    const toggleButton = getByLabelText('menu for actions');
+
+    fireEvent.click(toggleButton);
+
+    const option = getByText('Disabled option');
+    fireEvent.click(option);
+
+    expect(disabledOptionsMock[0].handleClick).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/Main/ActionsDropdown/index.jsx
+++ b/src/features/Main/ActionsDropdown/index.jsx
@@ -13,6 +13,7 @@ import Option from './Option';
  *   - `handleClick`: The function to call when the option is clicked.
  *   - `label`: The text to display for the option.
  *   - `visible`: Whether the option is visible
+ *   - `disabled`: Whether the option is disabled
  * @param {boolean} props.vertIcon Whether to use the vertical "more" icon.
  *
  * @returns {ReactElement} The rendered dropdown menu.
@@ -46,6 +47,7 @@ ActionsDropdown.propTypes = {
     handleClick: PropTypes.func.isRequired,
     label: PropTypes.string.isRequired,
     visible: PropTypes.bool,
+    disabled: PropTypes.bool,
   })).isRequired,
   vertIcon: PropTypes.bool,
 };

--- a/src/helpers/__test__/index.test.jsx
+++ b/src/helpers/__test__/index.test.jsx
@@ -4,6 +4,7 @@ import {
   eventManager,
   stringToDateType,
   isInvalidUserOrInstitution,
+  downloadFileFromBlob,
 } from 'helpers';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
@@ -157,5 +158,32 @@ describe('isInvalidUserOrInstitution', () => {
 
   test('returns false when id exists (even if null)', () => {
     expect(isInvalidUserOrInstitution('user', { id: null })).toBe(false);
+  });
+});
+
+describe('downloadFileFromBlob', () => {
+  test('creates a temporary link and triggers a download', () => {
+    const createObjectURL = jest.fn(() => 'blob:mock-url');
+    const revokeObjectURL = jest.fn();
+    window.URL.createObjectURL = createObjectURL;
+    window.URL.revokeObjectURL = revokeObjectURL;
+
+    const anchor = document.createElement('a');
+    const clickSpy = jest.spyOn(anchor, 'click').mockImplementation(() => {});
+    const setAttributeSpy = jest.spyOn(anchor, 'setAttribute');
+    const appendChildSpy = jest.spyOn(document.body, 'appendChild');
+    const createElementSpy = jest.spyOn(document, 'createElement').mockReturnValue(anchor);
+
+    downloadFileFromBlob('csv,data', 'gradebook.csv');
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(createElementSpy).toHaveBeenCalledWith('a');
+    expect(setAttributeSpy).toHaveBeenCalledWith('download', 'gradebook.csv');
+    expect(appendChildSpy).toHaveBeenCalledWith(anchor);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+
+    createElementSpy.mockRestore();
+    appendChildSpy.mockRestore();
   });
 });

--- a/src/helpers/index.jsx
+++ b/src/helpers/index.jsx
@@ -110,3 +110,22 @@ export const isInvalidUserOrInstitution = (username, institution) => {
 
   return !username || !hasValidInstitutionId;
 };
+
+/**
+ * Triggers a browser download for the given file data by creating a temporary
+ * object URL and simulating a click on an anchor element.
+ *
+ * @param {Blob|MediaSource} data - The file content to download.
+ * @param {string} fileName - The name to give the downloaded file.
+ */
+export const downloadFileFromBlob = (data, fileName) => {
+  const url = window.URL.createObjectURL(new Blob([data]));
+  const link = document.createElement('a');
+
+  link.href = url;
+  link.setAttribute('download', fileName);
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
# Description
Adds a new "Download gradebook" action to the class action menu, allowing administrators to download a class Gradebook as a CSV file. The action is available in every location where the existing "Gradebook" action appears, across both PSS and IP.

When triggered, it requests `{LMS_BASE_URL}/courses/{ccx_course_id}/ccx_grades.csv` and lets the browser download the resulting file.

## Ticket
https://pearson.atlassian.net/browse/PADV-3531

### Changes
- **api.js**: New `getGradebookCsv(classId)` that fetches the CSV as a blob via the authenticated HTTP client.
- **thunks.js**: New `downloadGradebookCsv(classId, showToast)` thunk that shows an in-progress notification, retrieves the CSV, triggers the browser download, and surfaces an error notification on failure.
- **Actions.jsx** (Class detail page) and **columns.jsx** (Classes table): New "Download gradebook" menu item placed alongside the existing "Gradebook" option, reusing the same `classId` (CCX course key) and display conditions.

### Manual test plan
1. Open a page containing the class action menu.
2. Confirm "Download gradebook" is displayed together with "Gradebook".
3. Click "Download gradebook" and verify a request is made to `{LMS_BASE_URL}/courses/{ccx_course_id}/ccx_grades.csv`.
4. Verify the browser downloads the CSV file.
5. Verify the action is disabled and labeled "Downloading gradebook…" while in progress, and that repeated clicks do not trigger multiple requests.
6. Confirm the existing "Gradebook" navigation still works without regressions.
